### PR TITLE
Stop suggesting performing GraphQL queries via HTTP GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ NOTE: If this is your new Rails + Solidus application, please don't forget to ru
 3) Add routes to your application's `config/routes.rb` to serve GraphQL and optionally also GraphiQL queries in development mode:
 
 ```ruby
-  get "/graphql", to: "spree/graphql#execute"
-  post "/graphql", to: "spree/graphql#execute"
+  post :graphql, to: 'graphql#execute'
 
   if Rails.env.development?
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
@@ -45,17 +44,13 @@ To run the whole app, run your usual `bundle exec rails s`.
 To perform a test GraphQL query, you can use any of the following methods:
 
 ```shell
-# If using HTTP GET (arguments passed as query strings):
-wget -qO- 'http://localhost:3000/graphql?query={ shop { name } }'
-GET 'http://localhost:3000/graphql?query={ shop { name } }'
-
-# If using HTTP POST (arguments passed in JSON body):
+# Using HTTP POST (arguments passed in JSON body):
 curl http://localhost:3000/graphql -H content-type:application/json -d '{ "query": " { shop { name } }" }'
 wget http://localhost:3000/graphql --header content-type:application/json -qO- --post-data '{ "query": " { shop { name } }" }'
 echo '{ "query": "{ shop { name } }" }' | POST -c application/json http://localhost:3000/graphql
 POST -c application/json http://localhost:3000/graphql <<< '{ "query": "{ shop { name } }" }'
 
-# If using HTTP POST with query strings (also works, may be simpler to write during testing):
+# Using HTTP POST with query strings (also works, may be simpler to write during testing):
 curl http://localhost:3000/graphql -d 'query={ shop { name } }'
 wget http://localhost:3000/graphql -qO- --post-data 'query={ shop { name } }'
 echo 'query={ shop { name } }' | POST http://localhost:3000/graphql

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ NOTE: If this is your new Rails + Solidus application, please don't forget to ru
   post "/graphql", to: "spree/graphql#execute"
 
   if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
+    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
   end
 ```
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,6 @@ RSpec.configure do |config|
 
   config.before do
     Spree::Core::Engine.routes.draw do
-      get :graphql, to: 'graphql#execute'
       post :graphql, to: 'graphql#execute'
     end
   end


### PR DESCRIPTION
Using GET method with GraphQL is very uncommon, due to GraphQL design which uses a single endpoint, even for non-idempotent actions (GraphQL mutations).