### PR TITLE
Handle code loading with Zeitwerk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/lib/solidus_graphql_api.rb
+++ b/lib/solidus_graphql_api.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
+require 'graphql'
 require 'solidus_core'
+require 'zeitwerk'
 
 module SolidusGraphqlApi; end
 
-require 'solidus_graphql_api/engine'
-require 'spree/graphql'
+require 'solidus_graphql_api/zeitwerk_inflector'
+
+loader = Zeitwerk::Loader.for_gem
+loader.inflector = SolidusGraphqlApi::ZeitwerkInflector.new __FILE__
+loader.ignore "#{__dir__}/solidus_graphql_api/zeitwerk_inflector.rb"
+loader.setup
+loader.eager_load

--- a/lib/solidus_graphql_api/zeitwerk_inflector.rb
+++ b/lib/solidus_graphql_api/zeitwerk_inflector.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SolidusGraphqlApi::ZeitwerkInflector < Zeitwerk::GemInflector
+  def camelize(basename, _abspath)
+    case basename
+    when 'graphql'
+      'GraphQL'
+    when 'url'
+      'URL'
+    else
+      super
+    end
+  end
+end

--- a/lib/spree/graphql.rb
+++ b/lib/spree/graphql.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module Spree::GraphQL; end
-
-require_relative './graphql/schema'

--- a/lib/spree/graphql/schema.rb
+++ b/lib/spree/graphql/schema.rb
@@ -4,48 +4,6 @@ require 'graphql'
 require 'ostruct'
 
 class Spree::GraphQL::Schema < ::GraphQL::Schema
-  module Inputs; end
-  module Interfaces; end
-  module Payloads; end
-  module Types; end
-
-  require_relative './not_implemented_error'
-
-  require_relative './schema/types/base_object'
-  require_relative './schema/types/base_object_node'
-  require_relative './schema/types/base_enum'
-  require_relative './schema/types/base_scalar'
-  require_relative './schema/inputs/base_input'
-  require_relative './schema/interfaces/base_interface'
-  require_relative './schema/payloads/base_payload'
-  require_relative './schema/types/base_union'
-  require_relative './schema/types/date_time'
-
-  require_relative './schema/types/country_code'
-  require_relative './schema/types/mailing_address'
-
-  require_relative './schema/types/decimal'
-  require_relative './schema/types/currency_code'
-  require_relative './schema/types/url'
-  require_relative './schema/types/html'
-  require_relative './schema/types/product_collection_sort_keys'
-  require_relative './schema/types/collection'
-  require_relative './schema/types/product_variant_sort_keys'
-  require_relative './schema/types/product_sort_keys'
-  require_relative './schema/types/product_variant'
-  require_relative './schema/types/product'
-
-  require_relative './schema/types/credit_card'
-  require_relative './schema/types/collection_sort_keys'
-
-  require_relative './domain'
-  require_relative './schema/types/domain'
-  require_relative './schema/types/payment_settings'
-  require_relative './schema/types/shop'
-
-  require_relative './schema/types/query_root'
-  require_relative './schema/types/mutation'
-
   query ::Spree::GraphQL::Schema::Types::QueryRoot
   mutation ::Spree::GraphQL::Schema::Types::Mutation
 

--- a/lib/spree/graphql/schema/types/collection.rb
+++ b/lib/spree/graphql/schema/types/collection.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::BaseObjectNode; end
 class Spree::GraphQL::Schema::Types::Collection < Spree::GraphQL::Schema::Types::BaseObjectNode
   graphql_name 'Collection'
 

--- a/lib/spree/graphql/schema/types/product.rb
+++ b/lib/spree/graphql/schema/types/product.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-class Spree::GraphQL::Schema::Types::ProductVariant < Spree::GraphQL::Schema::Types::BaseObjectNode; end
-
 class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::BaseObjectNode
   graphql_name 'Product'
 

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'graphql', '~> 1.9.3'
   s.add_dependency 'solidus_core', '>= 2.7.0'
+  s.add_dependency 'zeitwerk', '~> 2.1', '>= 2.1.2'
 
   s.add_development_dependency 'database_cleaner'
   # s.add_development_dependency 'byebug'


### PR DESCRIPTION
[Zeitwerk](https://github.com/fxn/zeitwerk) is a new code loader for Ruby, which will be the default code loader for Rails 6. Its integration allows us the removal of [empty namespaces definitions](https://github.com/solidusio-contrib/solidus_graphql_api/pull/53/files#diff-050218e9826450cc43b4c5f18fa00262L7), [internal code requires](https://github.com/solidusio-contrib/solidus_graphql_api/pull/53/files#diff-050218e9826450cc43b4c5f18fa00262L12) and circular dependencies conflicts hacks, such as [the definition of another constant used within the costant of the current file](https://github.com/solidusio-contrib/solidus_graphql_api/pull/53/files#diff-f03c56f888ff4fd2789106455ac60f41L3).