### PR TITLE
Product available

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi::ProductDecorator
+  module ClassMethods
+    def ransackable_scopes(_auth_object = nil)
+      (super || []) | %i[available]
+    end
+  end
+
+  def self.prepended(base)
+    class << base
+      prepend ClassMethods
+    end
+  end
+
+  Spree::Product.prepend self
+end

--- a/lib/spree/graphql/schema/types/product.rb
+++ b/lib/spree/graphql/schema/types/product.rb
@@ -8,18 +8,18 @@ class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::Ba
   product, as do services (such as equipment rental, work for hire, customization of another product or an extended
   warranty).'
 
-  field :available_for_sale, ::GraphQL::Types::Boolean, null: false do
-    description 'Indicates if at least one product variant is available for sale.'
+  field :available, ::GraphQL::Types::Boolean, null: false do
+    description 'Indicates if the product is available for sale.'
   end
-  def available_for_sale
-    raise ::Spree::GraphQL::NotImplementedError
+  def available
+    object.available?
   end
 
   field :available_on, ::Spree::GraphQL::Schema::Types::DateTime, null: false do
     description 'The first date and the time the product becomes available for sale online in your shop. If the
 `available_on` attribute is not set, the product does not appear among the store’s products for sale.'
   end
-  def published_at
+  def available_on
     object.available_on
   end
 

--- a/lib/spree/graphql/schema/types/query_root.rb
+++ b/lib/spree/graphql/schema/types/query_root.rb
@@ -24,7 +24,10 @@ class Spree::GraphQL::Schema::Types::QueryRoot < Spree::GraphQL::Schema::Types::
     argument :query,
              [Spree::GraphQL::Schema::Inputs::RansackQuery],
              required: false,
-             default_value: [{ 'key' => 's', 'value' => 'id asc' }],
+             default_value: [
+               { 'key' => 'available', 'value' => 'true' },
+               { 'key' => 's', 'value' => 'id asc' }
+             ],
              description: 'List of Ransack queries, can be used to filter and sort the results.'
   end
   def products(query:)


### PR DESCRIPTION
It includes the following hanges:

- implement `Product.available`
-  filter out not available products by default: it adds `available` to `ransackable_scopes` and sets it as default scope for GraphQL products queries in order to filter out not available products by default.