### PR TITLE
Add masterVariant field to product type

### DIFF
--- a/lib/spree/graphql/lazy_resolvers/batch_loader/product.rb
+++ b/lib/spree/graphql/lazy_resolvers/batch_loader/product.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Spree::GraphQL::LazyResolvers::BatchLoader::Product < Spree::GraphQL::LazyResolvers::Base
+  def master_variant
+    ::BatchLoader::GraphQL.for(object.id).batch do |product_ids, loader|
+      master_variant_batch(product_ids).each { |variant| loader.call(variant.product_id, variant) }
+    end
+  end
+
   def variants(including_master:, query:)
     query = Spree::GraphQL::Schema::Inputs::RansackQuery.queries_to_ransack_query(query)
 
@@ -12,6 +18,10 @@ class Spree::GraphQL::LazyResolvers::BatchLoader::Product < Spree::GraphQL::Lazy
   end
 
   private
+
+  def master_variant_batch(product_ids)
+    Spree::Variant.where(product_id: product_ids).where(is_master: true)
+  end
 
   def variants_batch(product_ids, query, including_master)
     variants = Spree::Variant.where(product_id: product_ids).ransack(query).result

--- a/lib/spree/graphql/schema/types/product.rb
+++ b/lib/spree/graphql/schema/types/product.rb
@@ -64,6 +64,14 @@ class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::Ba
     object.images.ransack(query).result
   end
 
+  field :master_variant, ::Spree::GraphQL::Schema::Types::Variant, null: false do
+    description 'The product’s master variant.'
+  end
+  def master_variant
+    object.master
+  end
+  delegate :master_variant, to: :lazy_resolver
+
   field :name, ::GraphQL::Types::String, null: false do
     description 'The product’s name.'
   end

--- a/spec/spree/graphql/schema/types/product_spec.rb
+++ b/spec/spree/graphql/schema/types/product_spec.rb
@@ -30,12 +30,15 @@ RSpec.describe Spree::GraphQL::Schema::Types::Product do
             products(first: 2) {
               edges {
                 node {
-                  createdAt
-                  updatedAt
                   availableOn
+                  createdAt
                   description
+                  masterVariant {
+                    id
+                  }
                   name
                   slug
+                  updatedAt
                 }
               }
             }
@@ -51,22 +54,28 @@ RSpec.describe Spree::GraphQL::Schema::Types::Product do
               edges: [
                 {
                   node: {
-                    createdAt: product.created_at.iso8601,
                     availableOn: product.available_on.iso8601,
-                    updatedAt: product.updated_at.iso8601,
+                    createdAt: product.created_at.iso8601,
                     description: product.description,
+                    masterVariant: {
+                      id: ::Spree::GraphQL::Schema.id_from_object(product.master)
+                    },
                     name: product.name,
-                    slug: product.slug
+                    slug: product.slug,
+                    updatedAt: product.updated_at.iso8601
                   }
                 },
                 {
                   node: {
-                    createdAt: product2.created_at.iso8601,
                     availableOn: product2.available_on.iso8601,
-                    updatedAt: product2.updated_at.iso8601,
+                    createdAt: product2.created_at.iso8601,
                     description: product2.description,
+                    masterVariant: {
+                      id: ::Spree::GraphQL::Schema.id_from_object(product2.master)
+                    },
                     name: product2.name,
-                    slug: product2.slug
+                    slug: product2.slug,
+                    updatedAt: product2.updated_at.iso8601
                   }
                 }
               ]


### PR DESCRIPTION
It allows fetching the product’s master variant without fetching all the variants.