### PR TITLE
Implement lazy execution logic with lazy resolvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ rvm:
   - 2.5
   - 2.6
 env:
-  - SOLIDUS_BRANCH=v2.7 DB=postgres
-  - SOLIDUS_BRANCH=v2.8 DB=postgres
-  - SOLIDUS_BRANCH=master DB=postgres
-  - SOLIDUS_BRANCH=v2.7 DB=mysql
-  - SOLIDUS_BRANCH=v2.8 DB=mysql
-  - SOLIDUS_BRANCH=master DB=mysql
+  global:
+    - LAZY_RESOLVER=batch-loader
+  matrix:
+    - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
+    - SOLIDUS_BRANCH=master DB=postgres
+    - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
+    - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,16 @@ solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: solidus_branch
 gem 'solidus_auth_devise'
 
-if ENV['DB'] == 'mysql'
+case ENV['DB']
+when 'mysql'
   gem 'mysql2', '~> 0.4.10'
-else
+when 'postgres'
   gem 'pg', '~> 0.21'
+end
+
+case ENV['LAZY_RESOLVER']
+when 'batch-loader'
+  gem 'batch-loader', '~> 1.4.0'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ gem 'graphiql-rails', group: :development
 
 2) Run `bundle`:
 
-```shell
+```sh
+bundle
+```
+
+3) Run the extension generator and run `bundle` again as it could insert additional dependencies:
+
+```sh
+bundle exec rails g solidus_graphql_api:install
 bundle
 ```
 
 NOTE: If this is your new Rails + Solidus application, please don't forget to run the Solidus installation steps, which at a minimum consist of adding the database `username`, `password`, and `host` in `config/database.yml`'s `default` block and running `bundle exec rails g spree:install`.
 
-3) Add routes to your application's `config/routes.rb` to serve GraphQL and optionally also GraphiQL queries in development mode:
+4) Add routes to your application's `config/routes.rb` to serve GraphQL and optionally also GraphiQL queries in development mode:
 
 ```ruby
   post :graphql, to: 'spree/graphql#execute'

--- a/app/models/solidus_graphql_api/configuration.rb
+++ b/app/models/solidus_graphql_api/configuration.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SolidusGraphqlApi::Configuration < Spree::Preferences::Configuration
+  preference :lazy_resolver_adapter_class_name,
+             :string,
+             default: 'Spree::GraphQL::LazyResolver::Adapters::BatchLoaderAdapter'
+end

--- a/lib/generators/solidus_graphql_api/install_generator.rb
+++ b/lib/generators/solidus_graphql_api/install_generator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SolidusGraphqlApi::InstallGenerator < Rails::Generators::Base
+  include Spree::GraphQL::LazyResolver.install_generator_helper
+
+  def add_lazy_resolvers_adapter_dependencies
+    super
+  end
+end

--- a/lib/solidus_graphql_api/engine.rb
+++ b/lib/solidus_graphql_api/engine.rb
@@ -12,6 +12,10 @@ class SolidusGraphqlApi::Engine < Rails::Engine
 
   config.eager_load_paths << File.expand_path('..', __dir__)
 
+  initializer 'solidus_graphql_api.environment', before: :load_config_initializers do |_app|
+    SolidusGraphqlApi::Config = SolidusGraphqlApi::Configuration.new
+  end
+
   def self.activate
     Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
       Rails.configuration.cache_classes ? require(c) : load(c)

--- a/lib/spree/graphql/lazy_resolver.rb
+++ b/lib/spree/graphql/lazy_resolver.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree::GraphQL::LazyResolver
+  ADAPTER = SolidusGraphqlApi::Config.lazy_resolver_adapter_class_name.constantize
+  private_constant :ADAPTER
+
+  METHODS_DELEGATED_TO_ADAPTER = %i[
+    activate
+    adapter_namespace
+    clear_cache
+    lookup_resolver_class
+    require_dependencies
+    resolvers_namespace
+  ].freeze
+
+  class << self
+    delegate(*METHODS_DELEGATED_TO_ADAPTER, to: :adapter)
+  end
+
+  def self.adapter
+    ADAPTER
+  end
+end

--- a/lib/spree/graphql/lazy_resolver.rb
+++ b/lib/spree/graphql/lazy_resolver.rb
@@ -8,6 +8,7 @@ module Spree::GraphQL::LazyResolver
     activate
     adapter_namespace
     clear_cache
+    install_generator_helper
     lookup_resolver_class
     require_dependencies
     resolvers_namespace

--- a/lib/spree/graphql/lazy_resolver/adapters/abstract_adapter.rb
+++ b/lib/spree/graphql/lazy_resolver/adapters/abstract_adapter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolver::Adapters::AbstractAdapter
+  def self.activate(_schema)
+    raise NotImplementedError
+  end
+
+  def self.adapter_namespace
+    to_s.sub(/Adapter\z/, '').constantize
+  end
+
+  def self.clear_cache
+    raise NotImplementedError
+  end
+
+  def self.lookup_resolver_class(graphql_type_class)
+    resolvers_namespace.const_get graphql_type_class.to_s.demodulize
+  end
+
+  def self.require_dependencies
+    raise NotImplementedError
+  end
+
+  def self.resolvers_namespace
+    raise NotImplementedError
+  end
+end

--- a/lib/spree/graphql/lazy_resolver/adapters/abstract_adapter.rb
+++ b/lib/spree/graphql/lazy_resolver/adapters/abstract_adapter.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Spree::GraphQL::LazyResolver::Adapters::AbstractAdapter
+  INSTALL_GENERATOR_HELPER_MODULE_NAME = 'InstallGeneratorHelper'
+  private_constant :INSTALL_GENERATOR_HELPER_MODULE_NAME
+
   def self.activate(_schema)
     raise NotImplementedError
   end
@@ -11,6 +14,10 @@ class Spree::GraphQL::LazyResolver::Adapters::AbstractAdapter
 
   def self.clear_cache
     raise NotImplementedError
+  end
+
+  def self.install_generator_helper
+    adapter_namespace.const_get INSTALL_GENERATOR_HELPER_MODULE_NAME
   end
 
   def self.lookup_resolver_class(graphql_type_class)

--- a/lib/spree/graphql/lazy_resolver/adapters/batch_loader/install_generator_helper.rb
+++ b/lib/spree/graphql/lazy_resolver/adapters/batch_loader/install_generator_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Spree::GraphQL::LazyResolver::Adapters::BatchLoader::InstallGeneratorHelper
+  def add_lazy_resolvers_adapter_dependencies
+    gem 'batch-loader', '~> 1.4.0'
+  end
+end

--- a/lib/spree/graphql/lazy_resolver/adapters/batch_loader_adapter.rb
+++ b/lib/spree/graphql/lazy_resolver/adapters/batch_loader_adapter.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolver::Adapters::BatchLoaderAdapter <
+  Spree::GraphQL::LazyResolver::Adapters::AbstractAdapter
+  def self.activate(schema)
+    require_dependencies
+
+    schema.use ::BatchLoader::GraphQL
+  end
+
+  def self.clear_cache
+    ::BatchLoader::Executor.clear_current
+  end
+
+  def self.require_dependencies
+    gem 'batch-loader', '~> 1.4.0'
+  end
+
+  def self.resolvers_namespace
+    Spree::GraphQL::LazyResolvers::BatchLoader
+  end
+end

--- a/lib/spree/graphql/lazy_resolver/type_helper.rb
+++ b/lib/spree/graphql/lazy_resolver/type_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spree::GraphQL::LazyResolver::TypeHelper
+  protected
+
+  def lazy_resolver
+    Spree::GraphQL::LazyResolvers.for(self.class).new(object, context)
+  end
+end

--- a/lib/spree/graphql/lazy_resolvers.rb
+++ b/lib/spree/graphql/lazy_resolvers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Spree::GraphQL::LazyResolvers
+  def self.for(graphql_type_class)
+    Spree::GraphQL::LazyResolver.lookup_resolver_class graphql_type_class
+  end
+end

--- a/lib/spree/graphql/lazy_resolvers/base.rb
+++ b/lib/spree/graphql/lazy_resolvers/base.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolvers::Base
+  attr_reader :object, :context
+
+  def initialize(object, context)
+    @object = object
+    @context = context
+  end
+end

--- a/lib/spree/graphql/lazy_resolvers/batch_loader/option_value.rb
+++ b/lib/spree/graphql/lazy_resolvers/batch_loader/option_value.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolvers::BatchLoader::OptionValue < Spree::GraphQL::LazyResolvers::Base
+  def option_type
+    ::BatchLoader::GraphQL.for(object.option_type_id).batch do |option_type_ids, loader|
+      option_type_batch(option_type_ids).each { |option_type| loader.call(option_type.id, option_type) }
+    end
+  end
+
+  private
+
+  def option_type_batch(option_type_ids)
+    Spree::OptionType.where(id: option_type_ids)
+  end
+end

--- a/lib/spree/graphql/lazy_resolvers/batch_loader/product.rb
+++ b/lib/spree/graphql/lazy_resolvers/batch_loader/product.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolvers::BatchLoader::Product < Spree::GraphQL::LazyResolvers::Base
+  def variants(including_master:, query:)
+    query = Spree::GraphQL::Schema::Inputs::RansackQuery.queries_to_ransack_query(query)
+
+    ::BatchLoader::GraphQL.for(object.id).batch(default_value: []) do |product_ids, loader|
+      variants_batch(product_ids, query, including_master).each do |variant|
+        loader.call(variant.product_id) { |memo| memo << variant }
+      end
+    end
+  end
+
+  private
+
+  def variants_batch(product_ids, query, including_master)
+    variants = Spree::Variant.where(product_id: product_ids).ransack(query).result
+    variants = variants.where(is_master: false) unless including_master
+    variants
+  end
+end

--- a/lib/spree/graphql/lazy_resolvers/batch_loader/variant.rb
+++ b/lib/spree/graphql/lazy_resolvers/batch_loader/variant.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class Spree::GraphQL::LazyResolvers::BatchLoader::Variant < Spree::GraphQL::LazyResolvers::Base
+  def images(query:)
+    query = Spree::GraphQL::Schema::Inputs::RansackQuery.queries_to_ransack_query(query)
+
+    ::BatchLoader::GraphQL.for(object.id).batch(default_value: []) do |variant_ids, loader|
+      images_batch(variant_ids, query).each do |image|
+        loader.call(image.viewable_id) { |memo| memo << image }
+      end
+    end
+  end
+
+  def option_values
+    ::BatchLoader::GraphQL.for(object.id).batch(default_value: []) do |variant_ids, loader|
+      option_values_batch(variant_ids).each do |option_values_variant|
+        loader.call(option_values_variant.variant_id) { |memo| memo << option_values_variant.option_value }
+      end
+    end
+  end
+
+  def price
+    pricing_options = context[:helpers].current_pricing_options
+
+    ::BatchLoader::GraphQL.for(object.id).batch(default_value: nil) do |variant_ids, loader|
+      price_batch(variant_ids).each do |price|
+        loader.call(price.variant_id) do |memo|
+          return memo if memo
+
+          price.try! :money if current_price?(price, pricing_options)
+        end
+      end
+    end
+  end
+
+  def prices
+    ::BatchLoader::GraphQL.for(object.id).batch(default_value: []) do |variant_ids, loader|
+      prices_batch(variant_ids).each do |price|
+        loader.call(price.variant_id) { |memo| memo << price.money }
+      end
+    end
+  end
+
+  def product
+    ::BatchLoader::GraphQL.for(object.product_id).batch do |product_ids, loader|
+      product_batch(product_ids).each { |product| loader.call(product.id, product) }
+    end
+  end
+
+  private
+
+  def images_batch(variant_ids, query)
+    Spree::Image.where(viewable_type: object.class.to_s, viewable_id: variant_ids).ransack(query).result
+  end
+
+  def option_values_batch(variant_ids)
+    Spree::OptionValuesVariant
+      .includes(:variant, :option_value)
+      .references(:option_value)
+      .where(variant_id: variant_ids)
+      .order(Spree::OptionValue.arel_table[:position].asc)
+  end
+
+  def price_batch(variant_ids)
+    prices_batch(variant_ids)
+  end
+
+  def prices_batch(variant_ids)
+    Spree::Price.currently_valid.where(variant_id: variant_ids)
+  end
+
+  def product_batch(product_ids)
+    Spree::Product.where(id: product_ids)
+  end
+
+  def current_price?(price, pricing_options)
+    (price.country_iso == pricing_options.desired_attributes[:country_iso] || price.country_iso.nil?) &&
+      price.currency == pricing_options.desired_attributes[:currency]
+  end
+end

--- a/lib/spree/graphql/schema.rb
+++ b/lib/spree/graphql/schema.rb
@@ -7,6 +7,8 @@ class Spree::GraphQL::Schema < ::GraphQL::Schema
   query ::Spree::GraphQL::Schema::Types::QueryRoot
   mutation ::Spree::GraphQL::Schema::Types::Mutation
 
+  Spree::GraphQL::LazyResolver.activate(self)
+
   def self.id_from_object(object, _type_definition = nil, _query_context = nil)
     ::GraphQL::Schema::UniqueWithinType.encode(object.class.name, object.id)
   end

--- a/lib/spree/graphql/schema/types/option_value.rb
+++ b/lib/spree/graphql/schema/types/option_value.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Spree::GraphQL::Schema::Types::OptionValue < Spree::GraphQL::Schema::Types::BaseObjectNode
+  include Spree::GraphQL::LazyResolver::TypeHelper
+
   graphql_name 'OptionValue'
 
   description <<~MD
@@ -18,9 +20,7 @@ class Spree::GraphQL::Schema::Types::OptionValue < Spree::GraphQL::Schema::Types
   field :option_type, ::Spree::GraphQL::Schema::Types::OptionType, null: false do
     description 'The option value’s option type.'
   end
-  def option_type
-    object.option_type
-  end
+  delegate :option_type, to: :lazy_resolver
 
   field :presentation, ::GraphQL::Types::String, null: false do
     description 'The option value’s presentation.'

--- a/lib/spree/graphql/schema/types/product.rb
+++ b/lib/spree/graphql/schema/types/product.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::BaseObjectNode
+  include Spree::GraphQL::LazyResolver::TypeHelper
+
   graphql_name 'Product'
 
   description 'A product represents an individual item for sale in a Solidus store. Products are often physical, but
@@ -92,8 +94,16 @@ class Spree::GraphQL::Schema::Types::Product < Spree::GraphQL::Schema::Types::Ba
 
   field :variants, ::Spree::GraphQL::Schema::Types::Variant.connection_type, null: false do
     description 'List of the product’s variants.'
+    argument :including_master,
+             ::GraphQL::Types::Boolean,
+             required: false,
+             default_value: false,
+             description: 'Whether the returned variants should include the master variant or not.'
+    argument :query,
+             [Spree::GraphQL::Schema::Inputs::RansackQuery],
+             required: false,
+             default_value: [{ 'key' => 's', 'value' => 'position asc' }],
+             description: 'List of Ransack queries, can be used to filter and sort the results.'
   end
-  def variants
-    object.variants
-  end
+  delegate :variants, to: :lazy_resolver
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,12 +27,18 @@ RSpec.configure do |config|
     metadata[:type] = :graphql
   end
 
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
   config.include Spree::GraphQL::Spec::Helpers, type: :graphql
 
   config.before do
     Spree::Core::Engine.routes.draw do
       post :graphql, to: 'graphql#execute'
     end
+  end
+
+  config.before type: :graphql do
+    Spree::GraphQL::LazyResolver.clear_cache
   end
 
   config.after(:all) do

--- a/spec/spree/graphql/lazy_resolver_spec.rb
+++ b/spec/spree/graphql/lazy_resolver_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::GraphQL::LazyResolver do
+  describe '.adapter' do
+    include_context 'when the lazy resolver adapter is BatchLoader' do
+      subject(:returned_value) { described_class.adapter }
+
+      it { is_expected.to eq Spree::GraphQL::LazyResolver::Adapters::BatchLoaderAdapter }
+    end
+  end
+
+  described_class::METHODS_DELEGATED_TO_ADAPTER.each do |delegated_method|
+    describe ".#{delegated_method}" do
+      include_context 'when the lazy resolver adapter is BatchLoader' do
+        it 'gets delegated to the adapter' do
+          expect(described_class.adapter).to receive(delegated_method)
+          described_class.send delegated_method
+        end
+      end
+    end
+  end
+end

--- a/spec/spree/graphql/lazy_resolvers_spec.rb
+++ b/spec/spree/graphql/lazy_resolvers_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::GraphQL::LazyResolvers do
+  describe '.for' do
+    subject(:returned_value) { described_class.for graphql_type_class }
+
+    include_context 'when the lazy resolver adapter is BatchLoader' do
+      context 'when it gets called with a GraphQL type class having a related lazy resolver' do
+        let(:graphql_type_class) { Spree::GraphQL::Schema::Types::Product }
+
+        it 'returns the related lazy resolver' do
+          expect(returned_value).to eq Spree::GraphQL::LazyResolvers::BatchLoader::Product
+        end
+      end
+    end
+  end
+end

--- a/spec/spree/graphql/schema/types/variant_spec.rb
+++ b/spec/spree/graphql/schema/types/variant_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Spree::GraphQL::Schema::Types::Variant do
-  let(:option_values) { create_list(:option_value, 2) }
+  let(:option_values) { Array.new(2) { |n| create(:option_value, position: n + 1) } }
   let!(:product) do
     p = create(:product)
     p.slug = 'product'
@@ -11,7 +11,7 @@ RSpec.describe Spree::GraphQL::Schema::Types::Variant do
     p
   end
   let!(:variant) do
-    v = create(:variant)
+    v = build(:variant)
     v.product = product
     v.weight = 5.84
     v.option_values = option_values

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'when the lazy resolver adapter is BatchLoader' do
+  before do
+    SolidusGraphqlApi::Config.lazy_resolver_adapter_class_name =
+      'Spree::GraphQL::LazyResolver::Adapters::BatchLoaderAdapter'
+  end
+end


### PR DESCRIPTION
To mitigate the N+1 queries problem I introduced the concept of lazy resolvers. Lazy resolvers are classes, instances of which are responsible for resolution of the GraphQL fields affected by N+1 queries. This is how it works:

The `Spree::GraphQL::LazyResolver::TypeHelper` module is included within GraphQL classes that require lazy execution logic. Such module defines a `lazy_resolver` protected method, to which the GraphQL type class delegates the resolution of the involved fields. The `lazy_resolver` method is responsible for finding the lazy resolver class associated to the selected lazy resolver adapter (more on the lazy resolver adapter below) and to the involved GraphQL type class. After the lazy resolver class is found, it gets initialized with the GraphQL type instance object and the GraphQL context, and the resolution of the GraphQL field is delegated to the created instance.

To let developers pick the lazy execution logic most fitting for them, or even implement their ones, LazyResolver uses the Adapter pattern. The default adapter (and the only one implemented at the
moment) is for the `batch-loader` gem. I chose `batch-loader` over the many alternatives (`graphql-batch`, `graphql` vanilla lazy resolvers, ...) for the following reasons:
- adequately popular
- maintained
- it implements the lazy object pattern, which is more idiomatic in the Ruby language context than the promise pattern, implemented by some of the other popular alternatives (`graphql-batch`, `dataloader`)
- I found it easy to use