### PR TITLE
Restrict Gemfile conditional gems scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,16 +9,18 @@ solidus_branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: solidus_branch
 gem 'solidus_auth_devise'
 
-case ENV['DB']
-when 'mysql'
-  gem 'mysql2', '~> 0.4.10'
-when 'postgres'
-  gem 'pg', '~> 0.21'
-end
+if ENV['CI']
+  case ENV['DB']
+  when 'mysql'
+    gem 'mysql2', '~> 0.4.10'
+  when 'postgres'
+    gem 'pg', '~> 0.21'
+  end
 
-case ENV['LAZY_RESOLVER']
-when 'batch-loader'
-  gem 'batch-loader', '~> 1.4.0'
+  case ENV['LAZY_RESOLVER']
+  when 'batch-loader'
+    gem 'batch-loader', '~> 1.4.0'
+  end
 end
 
 gemspec


### PR DESCRIPTION
The `Gemfile` conditionally adds dependecies basing on env vars
presence, allowing CI to setup the testing environment with different
dependencies. But such env vars could conflict with user env vars,
leading to redundant dependencies added to the users’ projects.

This commit restricts the env vars checks adding the `CI` env var
presence check. `CI` env var is a standard de facto for representing
continuous integration environments, and its presence checking should
reasonably ensure that we are in a CI context.