### PR TITLE
Add Wallet Type with the connection in User Type

### DIFF
--- a/lib/solidus_graphql_api.rb
+++ b/lib/solidus_graphql_api.rb
@@ -8,3 +8,4 @@ require 'solidus_support'
 
 require 'solidus_graphql_api/version'
 require 'solidus_graphql_api/engine'
+require 'solidus_graphql_api/configuration'

--- a/lib/solidus_graphql_api/configuration.rb
+++ b/lib/solidus_graphql_api/configuration.rb
@@ -9,5 +9,11 @@ module SolidusGraphqlApi
     @configuration ||= Configuration.new
   end
 
-  class Configuration; end
+  class Configuration
+    attr_accessor :payment_sources
+
+    def initialize
+      @payment_sources = [SolidusGraphqlApi::Types::CreditCard]
+    end
+  end
 end

--- a/lib/solidus_graphql_api/configuration.rb
+++ b/lib/solidus_graphql_api/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  class Configuration; end
+end

--- a/lib/solidus_graphql_api/types/credit_card.rb
+++ b/lib/solidus_graphql_api/types/credit_card.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class CreditCard < Base::RelayNode
+      description 'Credit Card.'
+
+      field :address, Address, null: false
+      field :cc_type, String, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :last_digits, String, null: false
+      field :month, String, null: false
+      field :name, String, null: false
+      field :payment_method, Types::PaymentMethod, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :year, String, null: false
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/credit_card.rb
+++ b/lib/solidus_graphql_api/types/credit_card.rb
@@ -3,16 +3,15 @@
 module SolidusGraphqlApi
   module Types
     class CreditCard < Base::RelayNode
+      implements Types::Interfaces::PaymentSource
+
       description 'Credit Card.'
 
       field :address, Address, null: false
       field :cc_type, String, null: false
-      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_digits, String, null: false
       field :month, String, null: false
       field :name, String, null: false
-      field :payment_method, Types::PaymentMethod, null: false
-      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :year, String, null: false
     end
   end

--- a/lib/solidus_graphql_api/types/interfaces/payment_source.rb
+++ b/lib/solidus_graphql_api/types/interfaces/payment_source.rb
@@ -6,6 +6,8 @@ module SolidusGraphqlApi
       module PaymentSource
         include Types::Base::Interface
 
+        orphan_types(*SolidusGraphqlApi.configuration.payment_sources)
+
         description "Payment Source."
 
         field :created_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/lib/solidus_graphql_api/types/interfaces/payment_source.rb
+++ b/lib/solidus_graphql_api/types/interfaces/payment_source.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    module Interfaces
+      module PaymentSource
+        include Types::Base::Interface
+
+        description "Payment Source."
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :payment_method, Types::PaymentMethod, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/payment_method.rb
+++ b/lib/solidus_graphql_api/types/payment_method.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class PaymentMethod < Base::RelayNode
+      description 'Payment Method.'
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :description, String, null: true
+      field :name, String, null: false
+      field :position, String, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/user.rb
+++ b/lib/solidus_graphql_api/types/user.rb
@@ -17,6 +17,7 @@ module SolidusGraphqlApi
       field :sign_in_count, Integer, null: false
       field :spree_api_key, String, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :wallet, Types::WalletPaymentSource.connection_type, method: :wallet_payment_sources, null: false
     end
   end
 end

--- a/lib/solidus_graphql_api/types/wallet_payment_source.rb
+++ b/lib/solidus_graphql_api/types/wallet_payment_source.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class WalletPaymentSource < Base::RelayNode
+      description 'Wallet Payment Source.'
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :default, Boolean, null: false
+      field :payment_source, Types::Interfaces::PaymentSource, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -126,6 +126,22 @@ type CountryEdge {
 }
 
 """
+Credit Card.
+"""
+type CreditCard implements Node & PaymentSource {
+  address: Address!
+  ccType: String!
+  createdAt: ISO8601DateTime
+  id: ID!
+  lastDigits: String!
+  month: String!
+  name: String!
+  paymentMethod: PaymentMethod!
+  updatedAt: ISO8601DateTime
+  year: String!
+}
+
+"""
 Currency.
 """
 type Currency implements Node {
@@ -520,6 +536,27 @@ type PageInfo {
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
+}
+
+"""
+Payment Method.
+"""
+type PaymentMethod implements Node {
+  createdAt: ISO8601DateTime
+  description: String
+  id: ID!
+  name: String!
+  position: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+Payment Source.
+"""
+interface PaymentSource {
+  createdAt: ISO8601DateTime
+  paymentMethod: PaymentMethod!
+  updatedAt: ISO8601DateTime
 }
 
 """
@@ -1198,6 +1235,27 @@ type User implements Node {
   signInCount: Int!
   spreeApiKey: String
   updatedAt: ISO8601DateTime
+  wallet(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): WalletPaymentSourceConnection!
 }
 
 """
@@ -1313,4 +1371,50 @@ type VariantEdge {
   The item at the end of the edge.
   """
   node: Variant
+}
+
+"""
+Wallet Payment Source.
+"""
+type WalletPaymentSource implements Node {
+  createdAt: ISO8601DateTime
+  default: Boolean!
+  id: ID!
+  paymentSource: PaymentSource
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for WalletPaymentSource.
+"""
+type WalletPaymentSourceConnection {
+  """
+  A list of edges.
+  """
+  edges: [WalletPaymentSourceEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [WalletPaymentSource]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type WalletPaymentSourceEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: WalletPaymentSource
 }

--- a/spec/integration/queries/current_user_spec.rb
+++ b/spec/integration/queries/current_user_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe_query :current_user, query: :current_user, freeze_date: true do
 
   let(:ship_address) { create(:ship_address, id: 1, zipcode: 10_001) }
   let(:bill_address) { create(:bill_address, id: 2, zipcode: 10_002) }
+  let(:credit_card) {
+    create(:credit_card,
+           user: user,
+           cc_type: 'visa',
+           address: ship_address,
+           payment_method: create(:payment_method, id: 1))
+  }
+
+  before do
+    wallet_payment_source = user.wallet.add credit_card
+    wallet_payment_source.update!(default: true)
+  end
 
   field :currentUser do
     context 'when context does not have current user' do
@@ -23,7 +35,9 @@ RSpec.describe_query :current_user, query: :current_user, freeze_date: true do
     context 'when context have current user' do
       let!(:query_context) { Hash[current_user: user] }
 
-      it { is_expected.to match_response(:current_user) }
+      let(:args) { { wallet: user.wallet } }
+
+      it { is_expected.to match_response(:current_user).with_args(args) }
     end
   end
 end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -126,6 +126,22 @@ type CountryEdge {
 }
 
 """
+Credit Card.
+"""
+type CreditCard implements Node & PaymentSource {
+  address: Address!
+  ccType: String!
+  createdAt: ISO8601DateTime
+  id: ID!
+  lastDigits: String!
+  month: String!
+  name: String!
+  paymentMethod: PaymentMethod!
+  updatedAt: ISO8601DateTime
+  year: String!
+}
+
+"""
 Currency.
 """
 type Currency implements Node {
@@ -520,6 +536,27 @@ type PageInfo {
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
+}
+
+"""
+Payment Method.
+"""
+type PaymentMethod implements Node {
+  createdAt: ISO8601DateTime
+  description: String
+  id: ID!
+  name: String!
+  position: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+Payment Source.
+"""
+interface PaymentSource {
+  createdAt: ISO8601DateTime
+  paymentMethod: PaymentMethod!
+  updatedAt: ISO8601DateTime
 }
 
 """
@@ -1198,6 +1235,27 @@ type User implements Node {
   signInCount: Int!
   spreeApiKey: String
   updatedAt: ISO8601DateTime
+  wallet(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): WalletPaymentSourceConnection!
 }
 
 """
@@ -1313,4 +1371,50 @@ type VariantEdge {
   The item at the end of the edge.
   """
   node: Variant
+}
+
+"""
+Wallet Payment Source.
+"""
+type WalletPaymentSource implements Node {
+  createdAt: ISO8601DateTime
+  default: Boolean!
+  id: ID!
+  paymentSource: PaymentSource
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for WalletPaymentSource.
+"""
+type WalletPaymentSourceConnection {
+  """
+  A list of edges.
+  """
+  edges: [WalletPaymentSourceEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [WalletPaymentSource]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type WalletPaymentSourceEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: WalletPaymentSource
 }

--- a/spec/support/graphql/queries/current_user.gql
+++ b/spec/support/graphql/queries/current_user.gql
@@ -135,5 +135,63 @@ query {
     signInCount
     spreeApiKey
     updatedAt
+    wallet {
+      nodes {
+        createdAt
+        default
+        id
+        paymentSource {
+          ... on CreditCard {
+            address {
+              address1
+              address2
+              alternativePhone
+              city
+              company
+              country {
+                isoName
+                iso
+                iso3
+                name
+                numcode
+                statesRequired
+                createdAt
+                updatedAt
+              }
+              createdAt
+              firstname
+              id
+              lastname
+              phone
+              state {
+                name
+                abbr
+                createdAt
+                updatedAt
+              }
+              stateName
+              updatedAt
+              zipcode
+            }
+            ccType
+            lastDigits
+            month
+            name
+            year
+          }
+          createdAt
+          updatedAt
+          paymentMethod {
+            createdAt
+            description
+            id
+            name
+            position
+            updatedAt
+          }
+        }
+        updatedAt
+      }
+    }
   }
 }

--- a/spec/support/graphql/responses/current_user.json.erb
+++ b/spec/support/graphql/responses/current_user.json.erb
@@ -168,7 +168,65 @@
       },
       "signInCount": 0,
       "spreeApiKey": "123",
-      "updatedAt": "2012-12-21T12:00:00Z"
+      "updatedAt": "2012-12-21T12:00:00Z",
+      "wallet": {
+        "nodes": [
+          {
+            "createdAt": "2012-12-21T12:00:00Z",
+            "default": true,
+            "id": <%= wallet.default_wallet_payment_source.id %>,
+            "paymentSource": {
+              "address": {
+                "address1": "A Different Road",
+                "address2": "Northwest",
+                "alternativePhone": "555-555-0199",
+                "city": "Herndon",
+                "company": "Company",
+                "country": {
+                  "isoName": "UNITED STATES",
+                  "iso": "US",
+                  "iso3": "USA",
+                  "name": "United States",
+                  "numcode": 840,
+                  "statesRequired": false,
+                  "createdAt": "2012-12-21T12:00:00Z",
+                  "updatedAt": "2012-12-21T12:00:00Z"
+                },
+                "createdAt": "2012-12-21T12:00:00Z",
+                "firstname": "John",
+                "id": 1,
+                "lastname": null,
+                "phone": "555-555-0199",
+                "state": {
+                  "name": "Alabama",
+                  "abbr": "AL",
+                  "createdAt": "2012-12-21T12:00:00Z",
+                  "updatedAt": "2012-12-21T12:00:00Z"
+                },
+                "stateName": null,
+                "updatedAt": "2012-12-21T12:00:00Z",
+                "zipcode": "10001"
+              },
+              "ccType": "visa",
+              "lastDigits": "1111",
+              "month": "12",
+              "name": "Spree Commerce",
+              "year": "2013",
+              "createdAt": "2012-12-21T12:00:00Z",
+              "updatedAt": "2012-12-21T12:00:00Z",
+              "paymentMethod": {
+                "createdAt": "2012-12-21T12:00:00Z",
+                "description": null,
+                "id": 1,
+                "name": "Credit Card",
+                "position": "1",
+                "updatedAt": "2012-12-21T12:00:00Z"
+              }
+            },
+            "updatedAt": "2012-12-21T12:00:00Z"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| #41 | :+1: | :+1: |

- [x] Add `PaymentMethod` Type:
  - All static fields refer to [`spree_payment_methods`](https://github.com/solidusio/solidus/blob/475d9db5d0291dd4aeddc58ec919988c336729bb/core/db/migrate/20160101010000_solidus_one_four.rb#L347-L361) table;
- [x] Add `CreditCard` Type:
  - All static fields refer to [`spree_credit_cards`](https://github.com/solidusio/solidus/blob/475d9db5d0291dd4aeddc58ec919988c336729bb/core/db/migrate/20160101010000_solidus_one_four.rb#L162-L178) table;
- [x] Add `PaymentSource` Interface:
  - Adds the `PaymentSource` interface with the common Payment Source fields. And implements the interface in the type that represents the default Solidus Payment Source (Spree::CreditCard);
- [x] Add `WalletPaymentSource` Type:
  - All fields refer to [`Spree::WalletPaymentSource`](https://github.com/solidusio/solidus/blob/master/core/app/models/spree/wallet_payment_source.rb) class attributes;
- [x] Add `WalletPaymentSource` connection in `User` Type:
  -  The `wallet` connection field, which returns the wallet payment sources associated to the current user. The method that represents this field is [`wallet_payment_sources`](https://github.com/solidusio/solidus/blob/475d9db5d0291dd4aeddc58ec919988c336729bb/core/app/models/spree/wallet.rb#L19-L24).
- [x] Make the gem configurable externally