### PR TITLE
Fix nullable fields in all types

### DIFF
--- a/lib/solidus_graphql_api/types/address.rb
+++ b/lib/solidus_graphql_api/types/address.rb
@@ -5,20 +5,20 @@ module SolidusGraphqlApi
     class Address < Base::RelayNode
       description 'Address.'
 
-      field :address1, String, null: true
+      field :address1, String, null: false
       field :address2, String, null: true
       field :alternative_phone, String, null: true
-      field :city, String, null: true
+      field :city, String, null: false
       field :company, String, null: true
-      field :country, Country, null: true
+      field :country, Country, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :firstname, String, null: true
+      field :firstname, String, null: false
       field :lastname, String, null: true
-      field :phone, String, null: true
+      field :phone, String, null: false
       field :state_name, String, null: true
       field :state, State, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :zipcode, String, null: true
+      field :zipcode, String, null: false
 
       def state
         Queries::Address::StateQuery.new(address: object).call

--- a/lib/solidus_graphql_api/types/store.rb
+++ b/lib/solidus_graphql_api/types/store.rb
@@ -6,18 +6,18 @@ module SolidusGraphqlApi
       description 'Store.'
 
       field :cart_tax_country_iso, String, null: true
-      field :code, String, null: true
+      field :code, String, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
       field :currencies, Currency.connection_type, null: false
       field :default_currency, String, null: true
       field :default, Boolean, null: false
-      field :mail_from_address, String, null: true
+      field :mail_from_address, String, null: false
       field :meta_description, String, null: true
       field :meta_keywords, String, null: true
-      field :name, String, null: true
+      field :name, String, null: false
       field :seo_title, String, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :url, String, null: true
+      field :url, String, null: false
 
       def currencies
         Spree::Config.available_currencies

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,21 +2,21 @@
 Address.
 """
 type Address implements Node {
-  address1: String
+  address1: String!
   address2: String
   alternativePhone: String
-  city: String
+  city: String!
   company: String
-  country: Country
+  country: Country!
   createdAt: ISO8601DateTime
-  firstname: String
+  firstname: String!
   id: ID!
   lastname: String
-  phone: String
+  phone: String!
   state: State
   stateName: String
   updatedAt: ISO8601DateTime
-  zipcode: String
+  zipcode: String!
 }
 
 """
@@ -1091,7 +1091,7 @@ Store.
 """
 type Store implements Node {
   cartTaxCountryIso: String
-  code: String
+  code: String!
   createdAt: ISO8601DateTime
   currencies(
     """
@@ -1117,13 +1117,13 @@ type Store implements Node {
   default: Boolean!
   defaultCurrency: String
   id: ID!
-  mailFromAddress: String
+  mailFromAddress: String!
   metaDescription: String
   metaKeywords: String
-  name: String
+  name: String!
   seoTitle: String
   updatedAt: ISO8601DateTime
-  url: String
+  url: String!
 }
 
 """

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -2,21 +2,21 @@
 Address.
 """
 type Address implements Node {
-  address1: String
+  address1: String!
   address2: String
   alternativePhone: String
-  city: String
+  city: String!
   company: String
-  country: Country
+  country: Country!
   createdAt: ISO8601DateTime
-  firstname: String
+  firstname: String!
   id: ID!
   lastname: String
-  phone: String
+  phone: String!
   state: State
   stateName: String
   updatedAt: ISO8601DateTime
-  zipcode: String
+  zipcode: String!
 }
 
 """

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -1091,7 +1091,7 @@ Store.
 """
 type Store implements Node {
   cartTaxCountryIso: String
-  code: String
+  code: String!
   createdAt: ISO8601DateTime
   currencies(
     """
@@ -1117,13 +1117,13 @@ type Store implements Node {
   default: Boolean!
   defaultCurrency: String
   id: ID!
-  mailFromAddress: String
+  mailFromAddress: String!
   metaDescription: String
   metaKeywords: String
-  name: String
+  name: String!
   seoTitle: String
   updatedAt: ISO8601DateTime
-  url: String
+  url: String!
 }
 
 """


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| N/A | :+1: | :-1: |

Incorrectly declared fields were found in the following types:
- `SolidusGraphqlApi::Types::Address`
- `SolidusGraphqlApi::Types::Store`

All changes are made by comparing the GraphQL types with the validations present in their Solidus models.

Note
---
The null settings in `SolidusGraphqlApi::Types::Address` of these two fields:
```ruby
field :phone, String, null: false
field :zipcode, String, null: false
```
Depends since the Boolean return value of these two [`Spree::Address`](https://github.com/solidusio/solidus/blob/d456b1113de5111c3035f517ba6427e4b679bd18/core/app/models/spree/address.rb#L15-L16) instance methods (true):
```ruby
validates :zipcode, presence: true, if: :require_zipcode?
validates :phone, presence: true, if: :require_phone?
```
The current type definition refers to the current default configuration in Solidus.

