### PR TITLE
Now the ProductsQueryInput correctly accepts a relay-style ID for Taxon

### DIFF
--- a/lib/solidus_graphql_api/queries/products_query.rb
+++ b/lib/solidus_graphql_api/queries/products_query.rb
@@ -11,10 +11,18 @@ module SolidusGraphqlApi
       end
 
       def call(query: {})
-        Spree::Config.searcher_class.new(query).tap do |searcher|
+        Spree::Config.searcher_class.new(build_query(query)).tap do |searcher|
           searcher.current_user = user
           searcher.pricing_options = pricing_options
         end.retrieve_products.except(:limit, :offset)
+      end
+
+      private
+
+      def build_query(query)
+        query.to_h.tap do |q|
+          q[:taxon] = q[:taxon].id unless q[:taxon].nil?
+        end
       end
     end
   end

--- a/lib/solidus_graphql_api/types/input_objects/products_query_input.rb
+++ b/lib/solidus_graphql_api/types/input_objects/products_query_input.rb
@@ -6,7 +6,7 @@ module SolidusGraphqlApi
       class ProductsQueryInput < Base::InputObject
         description "Params for searching products."
 
-        argument :taxon, ID, "Taxon", required: false
+        argument :taxon, ID, "Taxon", required: false, loads: Types::Taxon
         argument :keywords, String, "Keywords", required: false
         argument :search, Types::RansackJson, "Search", required: false
       end

--- a/spec/integration/queries/products_spec.rb
+++ b/spec/integration/queries/products_spec.rb
@@ -28,10 +28,12 @@ RSpec.describe_query :products, query: :products, freeze_date: true do
       end
 
       context 'when a query is passed' do
+        let(:taxon) { create(:taxon, products: [solidus_tote]) }
         let(:search) { { price_range_any: ["Under $10.00", "$15.00 - $18.00"] } }
-        let(:query_variables) { { query: { keywords: "Solidus", search: search } } }
+        let(:taxon_id) { SolidusGraphqlApi::Schema.id_from_object(taxon, nil, nil) }
+        let(:query_variables) { { query: { taxon: taxon_id, keywords: "Solidus", search: search } } }
 
-        it { is_expected.to match_array([{ id: solidus_mug.id }, { id: solidus_tote.id }]) }
+        it { is_expected.to match_array([{ id: solidus_tote.id }]) }
       end
     end
   end

--- a/spec/lib/solidus_graphql_api/queries/products_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/products_query_spec.rb
@@ -28,19 +28,12 @@ RSpec.describe SolidusGraphqlApi::Queries::ProductsQuery do
 
     context 'when a query is passed' do
       let(:taxonomy) { create(:taxonomy, name: 'Categories') }
-      let(:t_shirts_taxon) { create(:taxon, name: 'T-Shirts', taxonomy: taxonomy) }
-      let(:mugs_taxon) { create(:taxon, name: 'Mugs', taxonomy: taxonomy) }
-      let(:totes_taxon) { create(:taxon, name: 'Totes', taxonomy: taxonomy) }
+      let(:t_shirts_taxon) { create(:taxon, name: 'T-Shirts', taxonomy: taxonomy, products: [solidus_t_shirt]) }
+      let(:mugs_taxon) { create(:taxon, name: 'Mugs', taxonomy: taxonomy, products: [ruby_mug, solidus_mug]) }
+      let(:totes_taxon) { create(:taxon, name: 'Totes', taxonomy: taxonomy, products: [solidus_tote]) }
 
       let(:search) { { price_range_any: ["Under $10.00", "$15.00 - $18.00"] } }
-      let(:query) { { taxon: totes_taxon.id, keywords: "Solidus", search: search } }
-
-      before do
-        solidus_t_shirt.taxons << t_shirts_taxon
-        ruby_mug.taxons << mugs_taxon
-        solidus_mug.taxons << mugs_taxon
-        solidus_tote.taxons << totes_taxon
-      end
+      let(:query) { { taxon: totes_taxon, keywords: "Solidus", search: search } }
 
       it { is_expected.to match_array([solidus_tote]) }
 


### PR DESCRIPTION
There was an issue in how the taxon argument was used in the
ProductsQueryInput, but now the argument is correctly treated as a
relay-style ID.