### PR TITLE
Update badges link paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Maintainability](https://api.codeclimate.com/v1/badges/1629331b266450721936/maintainability)](https://codeclimate.com/github/nebulab/solidus_graphql_api-1/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/1629331b266450721936/test_coverage)](https://codeclimate.com/github/nebulab/solidus_graphql_api-1/test_coverage)
-[![CircleCI](https://circleci.com/gh/nebulab/solidus_graphql_api-1.svg?style=svg)](https://circleci.com/gh/nebulab/solidus_graphql_api-1)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1629331b266450721936/maintainability)](https://codeclimate.com/github/solidusio-contrib/solidus_graphql_api/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/1629331b266450721936/test_coverage)](https://codeclimate.com/github/solidusio-contrib/solidus_graphql_api/test_coverage)
+[![CircleCI](https://circleci.com/gh/solidusio-contrib/solidus_graphql_api.svg?style=svg)](https://circleci.com/gh/solidusio-contrib/solidus_graphql_api)
 
 SolidusGraphqlApi
 =================


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| N/A | :-1: | :-1: |

The repository has recently been moved:
- From `nebulab/solidus_graphql_api-1`
- To `solidusio-contrib/solidus_graphql_api`

For this reason, these updates:
- `Code Climate CLI` `maintainability` and `test coverage` badge links;
- `CircleCI` badge link that refers to the last master branch workflow result.