### PR TITLE
Fix `Duplicate type definition` error during runtime changes in dev environment

### DIFF
--- a/lib/solidus_graphql_api/configuration.rb
+++ b/lib/solidus_graphql_api/configuration.rb
@@ -13,7 +13,7 @@ module SolidusGraphqlApi
     attr_accessor :payment_sources
 
     def initialize
-      @payment_sources = [SolidusGraphqlApi::Types::CreditCard]
+      @payment_sources = ['SolidusGraphqlApi::Types::CreditCard']
     end
   end
 end

--- a/lib/solidus_graphql_api/types/interfaces/payment_source.rb
+++ b/lib/solidus_graphql_api/types/interfaces/payment_source.rb
@@ -6,7 +6,7 @@ module SolidusGraphqlApi
       module PaymentSource
         include Types::Base::Interface
 
-        orphan_types(*SolidusGraphqlApi.configuration.payment_sources)
+        orphan_types(*SolidusGraphqlApi.configuration.payment_sources.map(&:constantize))
 
         description "Payment Source."
 


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| N/A | :-1: | :-1: |

With these changes, in the `payment_sources` configuration param, uses strings to force the correct autoloading of all the classes which are re-converted into constants during the `orphan_type` assignment and stop the circular dependencies errors in `dev` environment.

Note
---
This is a problem that probably occurred only in the development environment:
Because the `cache_classes` config flag in Solidus `cofing/environments/development.rb` configuration is usually set to `false`.

Info
---
For more information about this problem, consult these issues in `graphql-ruby`:
https://github.com/rmosolgo/graphql-ruby/issues/2716
https://github.com/rmosolgo/graphql-ruby/issues/935