### PR TITLE
Add the BatchLoader middleware

### DIFF
--- a/lib/solidus_graphql_api/engine.rb
+++ b/lib/solidus_graphql_api/engine.rb
@@ -16,5 +16,9 @@ module SolidusGraphqlApi
     end
 
     config.autoload_paths << File.expand_path('..', __dir__)
+
+    initializer "solidus_graphql_api.setup_batch_loader_middleware" do |app|
+      app.middleware.use BatchLoader::Middleware
+    end
   end
 end


### PR DESCRIPTION
By default `BatchLoader` caches the loaded values[1]. To ensure that the cache is purged between requests, we have to add the `BatchLoader::Middleware` to the rails application using an initializer[2].

[1] https://github.com/exAspArk/batch-loader#caching
[2] https://api.rubyonrails.org/classes/Rails/Railtie.html