### PR TITLE
Fix specs for Solidus version >= 2.11.0.alpha

### DIFF
--- a/lib/solidus_graphql_api/factories.rb
+++ b/lib/solidus_graphql_api/factories.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'solidus_graphql_api/factories/address_factory'
 require 'solidus_graphql_api/factories/country_factory'
 require 'solidus_graphql_api/factories/store_factory'
 require 'solidus_graphql_api/factories/taxonomy_factory'

--- a/lib/solidus_graphql_api/factories/address_factory.rb
+++ b/lib/solidus_graphql_api/factories/address_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.modify do
+  factory :address do
+    firstname { 'John' }
+    lastname { nil }
+  end
+end


### PR DESCRIPTION
The Solidus address factory was changed in this commit:

https://github.com/solidusio/solidus/commit/12bdceb#diff-bcf5b7751ffe7e9a0b057cf8e449951f

and the lastname is now "Von Doe" instead of nil, this fixes the issue
modifying the original factory and setting the firstname and lastname.