### PR TITLE
Set shippingAddress and billingAddress order's fields as nullable

### DIFF
--- a/lib/solidus_graphql_api/types/order.rb
+++ b/lib/solidus_graphql_api/types/order.rb
@@ -8,7 +8,7 @@ module SolidusGraphqlApi
       field :additional_tax_total, String, null: false
       field :adjustment_total, String, null: false
       field :approved_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :billing_address, Address, null: false
+      field :billing_address, Address, null: true
       field :canceled_at, GraphQL::Types::ISO8601DateTime, null: true
       field :completed_at, GraphQL::Types::ISO8601DateTime, null: true
       field :confirmation_delivered, Boolean, null: false
@@ -28,7 +28,7 @@ module SolidusGraphqlApi
       field :shipment_state, String, null: false
       field :shipment_total, String, null: false
       field :shipments, Shipment.connection_type, null: false
-      field :shipping_address, Address, null: false
+      field :shipping_address, Address, null: true
       field :special_instructions, String, null: true
       field :state, String, null: false
       field :total, String, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -705,7 +705,7 @@ type Order implements Node {
   adjustmentTotal: String!
   approvedAt: ISO8601DateTime
   availablePaymentMethods: [PaymentMethod!]!
-  billingAddress: Address!
+  billingAddress: Address
   canceledAt: ISO8601DateTime
   completedAt: ISO8601DateTime
   confirmationDelivered: Boolean!
@@ -765,7 +765,7 @@ type Order implements Node {
     """
     last: Int
   ): ShipmentConnection!
-  shippingAddress: Address!
+  shippingAddress: Address
   specialInstructions: String
   state: String!
   total: String!

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -705,7 +705,7 @@ type Order implements Node {
   adjustmentTotal: String!
   approvedAt: ISO8601DateTime
   availablePaymentMethods: [PaymentMethod!]!
-  billingAddress: Address!
+  billingAddress: Address
   canceledAt: ISO8601DateTime
   completedAt: ISO8601DateTime
   confirmationDelivered: Boolean!
@@ -765,7 +765,7 @@ type Order implements Node {
     """
     last: Int
   ): ShipmentConnection!
-  shippingAddress: Address!
+  shippingAddress: Address
   specialInstructions: String
   state: String!
   total: String!


### PR DESCRIPTION
When creating a new order the billing and shipping addresses are not setted yet.