### PR TITLE
Recalculate the order after update the attributes in the checkout mutations

### DIFF
--- a/lib/solidus_graphql_api/mutations/checkout/add_addresses_to_checkout.rb
+++ b/lib/solidus_graphql_api/mutations/checkout/add_addresses_to_checkout.rb
@@ -22,9 +22,14 @@ module SolidusGraphqlApi
             use_billing: ship_to_billing_address
           }
 
-          Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+          if Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+            current_order.recalculate
+            errors = []
+          else
+            errors = current_order.errors
+          end
 
-          { errors: user_errors('order', current_order.errors), order: current_order.reload }
+          { errors: user_errors('order', errors), order: current_order }
         end
 
         def ready?(*)

--- a/lib/solidus_graphql_api/mutations/checkout/add_payment_to_checkout.rb
+++ b/lib/solidus_graphql_api/mutations/checkout/add_payment_to_checkout.rb
@@ -24,12 +24,14 @@ module SolidusGraphqlApi
             }]
           }
 
-          Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+          if Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+            current_order.recalculate
+            errors = []
+          else
+            errors = current_order.errors
+          end
 
-          {
-            errors: user_errors('order', current_order.errors),
-            order: current_order.reload
-          }
+          { errors: user_errors('order', errors), order: current_order }
         end
 
         private

--- a/lib/solidus_graphql_api/mutations/checkout/select_shipping_rate.rb
+++ b/lib/solidus_graphql_api/mutations/checkout/select_shipping_rate.rb
@@ -21,12 +21,14 @@ module SolidusGraphqlApi
             }
           }
 
-          Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+          if Spree::OrderUpdateAttributes.new(current_order, update_params).apply
+            current_order.recalculate
+            errors = []
+          else
+            errors = current_order.errors
+          end
 
-          {
-            errors: user_errors('order', current_order.errors),
-            order: current_order.reload
-          }
+          { errors: user_errors('order', errors), order: current_order }
         end
 
         def ready?(*)

--- a/spec/integration/mutations/checkout/add_payment_to_checkout_spec.rb
+++ b/spec/integration/mutations/checkout/add_payment_to_checkout_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe_mutation :add_payment_to_checkout, mutation: :add_payment_to_chec
         it { expect(subject[:errors].first[:message]).to eq I18n.t(:'activerecord.exceptions.not_found') }
       end
 
+      context "when there are errors during payment method selection" do
+        let(:payment_method_id) { SolidusGraphqlApi::Schema.id_from_object(payment_method, nil, nil) }
+
+        before do
+          order_updater = instance_double('Spree::OrderUpdateAttributes', apply: false)
+          allow(Spree::OrderUpdateAttributes).to receive(:new).and_return(order_updater)
+        end
+
+        it { expect(subject[:data][:addPaymentToCheckout]).to have_key(:errors) }
+      end
+
       context "when the given payment method id is correct" do
         let(:payment_method_id) { SolidusGraphqlApi::Schema.id_from_object(payment_method, nil, nil) }
 

--- a/spec/integration/mutations/checkout/select_shipping_rate_spec.rb
+++ b/spec/integration/mutations/checkout/select_shipping_rate_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe_mutation :select_shipping_rate, mutation: :select_shipping_rate d
         it { expect(subject[:errors].first[:message]).to eq I18n.t(:'activerecord.exceptions.not_found') }
       end
 
+      context "when there are errors during shipping rate selection" do
+        let(:selected_shipping_rate_id) { SolidusGraphqlApi::Schema.id_from_object(shipping_rate, nil, nil) }
+        let(:shipping_rate_id) { selected_shipping_rate_id }
+
+        before do
+          order_updater = instance_double('Spree::OrderUpdateAttributes', apply: false)
+          allow(Spree::OrderUpdateAttributes).to receive(:new).and_return(order_updater)
+        end
+
+        it { expect(subject[:data][:selectShippingRate]).to have_key(:errors) }
+      end
+
       context "when the given shipping rate id is correct" do
         let(:selected_shipping_rate_id) { SolidusGraphqlApi::Schema.id_from_object(shipping_rate, nil, nil) }
         let(:shipping_rate_id) { selected_shipping_rate_id }


### PR DESCRIPTION
The recalculate is needed because the `Spree::OrderUpdateAttributes#apply` method doesn't call it and we have to return the update order informations.