### PR TITLE
Make dependency on Rails > 6.1 explicit

### DIFF
--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'batch-loader', '>= 1.4.1', '< 1.6.0'
   spec.add_dependency 'graphql', '>= 1.10', '< 1.12'
-  spec.add_dependency 'solidus_core', ['>= 2.5', '< 4']
+  spec.add_dependency 'rails', '~> 6.1'
+  spec.add_dependency 'solidus_core', ['>= 2.10', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.6'
 
   spec.add_development_dependency 'graphql-docs', '~> 2.0.1'


### PR DESCRIPTION
There's at least one part of the extension that is not compatible with
Rails < 6.1. The `ActiveModel::Errors` handling maps the error
collection assuming that what is yielded is an instance of
`ActiveModel::Error` (call to `error.attribute`):

https://github.com/solidusio-contrib/solidus_graphql_api/blob/9629e8d6b5ee5767265c3e1068a13b2677430a98/lib/solidus_graphql_api/mutations/base_mutation.rb#L36-L41

However, the [`ActiveModel::Error` object is only available from Rails
6.1](https://guides.rubyonrails.org/6_1_release_notes.html#active-model-notable-changes), and before that [it was yielded the error key and message](https://api.rubyonrails.org/v6.0.0/classes/ActiveModel/Errors.html#method-i-each).

We also bump the minimal requirement for Solidus to 2.10, as it's the
first version that [supported Rails 6.1](https://rubygems.org/gems/solidus_core/versions/2.10.0) (last [2.9
version didn't support it](https://rubygems.org/gems/solidus_core/versions/2.9.6)).