### PR TITLE
Fix user impersonation security vulnerability

### DIFF
--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -22,7 +22,11 @@ module SolidusGraphqlApi
     end
 
     def current_user
-      @current_user ||= Spree.user_class.find_by(spree_api_key: bearer_token)
+      @current_user ||= begin
+        return nil unless bearer_token&.present?
+
+        Spree.user_class.find_by(spree_api_key: bearer_token)
+      end
     end
 
     def current_ability

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -58,8 +58,62 @@ RSpec.describe SolidusGraphqlApi::Context do
   describe '#current_user' do
     subject { schema_context.current_user }
 
-    context 'when headers do not contains the authorization token' do
-      it { is_expected.to be_nil }
+    context 'when headers do not contain the authorization token' do
+      context "and there's no user with nil or empty spree_api_key" do
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with nil spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: nil) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with empty string as spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: '') }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context 'when headers contain an empty authorization token' do
+      let(:authorization_token) { '' }
+
+      context "and there's no user with nil or empty spree_api_key" do
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with nil spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: nil) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with empty string as spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: '') }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    context "when headers contain a authorization header that doesn't match" do
+      let(:headers) { { 'Authorization' => 'abc' } }
+
+      context "and there's no user with nil or empty spree_api_key" do
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with nil spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: nil) }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "and there's a user with empty string as spree_api_key" do
+        before { FactoryBot.create(:user, spree_api_key: '') }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context 'when headers contains the authorization token' do


### PR DESCRIPTION
This commit fixes two bugs where an unauthenticated user was able to
impersonate a registered user.

1. When a request was made with no `Authentication` header, the system
returned as the current user the first one encountered with `NULL`
`spree_api_key`. That's because `Context#bearer_token` ended up being
`nil`, and that was given to the `#find_by(spree_api_key:
spree_api_key)` query in `Context#current_user`.

2. When a request was made with an `Authentication` header equal to `Bearer
`, the system returned as the current user the first one encountered
with `''` `spree_api_key`. That's because `Context#bearer_token` ended
up being `''`, and that was given to the `#find_by(spree_api_key:
spree_api_key)` query in `Context#current_user`.

The first one is the most likely to have hit `solidus_graphql_api`
users, as `spree_api_key` is `NULL` by default. However, most
installations will have users with populated `spree_api_key`, as it's
needed to perform GraphQL authenticated mutations.

We also add tests for other combinations to make the suite more
comprehensive.