### PR TITLE
Fix remote possibility to return wrong current order

### DIFF
--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -60,6 +60,8 @@ module SolidusGraphqlApi
     end
 
     def current_order_by_guest_token
+      return if order_token.blank?
+
       incomplete_orders = Spree::Order.incomplete
       incomplete_orders = incomplete_orders.where(store: current_store) if current_store
 

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -235,9 +235,61 @@ RSpec.describe SolidusGraphqlApi::Context do
         it { is_expected.to be_nil }
       end
 
+      # Need to bypass application layer to reproduce race database state
+      # rubocop:disable Rails/SkipsModelValidations
       context 'when is provided no order token' do
-        it { is_expected.to be_nil }
+        context "and there's no order with nil or empty guest_token" do
+          it { is_expected.to be_nil }
+        end
+
+        context "and there's an order with nil guest_token" do
+          before do
+            order = FactoryBot.create(:order)
+            order.update_column(:guest_token, nil)
+          end
+
+          it { is_expected.to be_nil }
+        end
+
+        context "and there's an order with empty string as guest_token" do
+          before do
+            order = FactoryBot.create(:order)
+            order.update_column(:guest_token, '')
+          end
+
+          it { is_expected.to be_nil }
+        end
       end
+      # rubocop:enable Rails/SkipsModelValidations
+
+      # Need to bypass application layer to reproduce race database state
+      # rubocop:disable Rails/SkipsModelValidations
+      context 'when is provided an empty order token' do
+        let(:order_token) { '' }
+
+        context "and there's no order with nil or empty guest_token" do
+          it { is_expected.to be_nil }
+        end
+
+        context "and there's an order with nil guest_token" do
+          before do
+            order = FactoryBot.create(:order)
+            order.update_column(:guest_token, nil)
+          end
+
+          it { is_expected.to be_nil }
+        end
+
+        context "and there's an order with empty string as guest_token" do
+          before do
+            order = FactoryBot.create(:order)
+            order.update_column(:guest_token, '')
+          end
+
+          it { is_expected.to be_nil }
+        end
+      end
+      # rubocop:enable Rails/SkipsModelValidations
     end
   end
 end


### PR DESCRIPTION
Orders' guest token is always populated thanks to a [`before_create`
callback on the application
layer](https://github.com/solidusio/solidus/blob/ea200dfcc03ed542ab130317ccab4f365c31af7e/core/app/models/spree/order.rb#L128).
However, it can be `NULL` in the database.

This commit makes sure that no order is returned in two situations:

1. `X-Spree-Order-Token` is not given, and it exists an order with
   `NULL` guest token.
2. `X-Spree-Order-Token` is provided as an empty string, and it exists
   an order with an empty string as a guest token.

Being defensive against these two options leaves us on the safe side if
business rules around the guest token change at some point in
solidus-core.

This problem is similar to what is fixed in #182