### PR TITLE
Add option_type field within OptionValue type

### DIFF
--- a/docs/object/optionvalue/index.html
+++ b/docs/object/optionvalue/index.html
@@ -1103,6 +1103,11 @@
   </div>
 </div>
 <div class="field-entry ">
+  <span id="optiontype" class="field-name anchored">optionType (<code><a href="/solidus_graphql_api/docs/object/optiontype">OptionType!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
   <span id="position" class="field-name anchored">position (<code><a href="/solidus_graphql_api/docs/scalar/string">String!</a></code>)</span>
   <div class="description-wrapper">
   </div>

--- a/lib/solidus_graphql_api/queries/option_value/option_type_query.rb
+++ b/lib/solidus_graphql_api/queries/option_value/option_type_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module OptionValue
+      class OptionTypeQuery
+        attr_reader :option_value
+
+        def initialize(option_value:)
+          @option_value = option_value
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(option_value, :option_type)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/option_value.rb
+++ b/lib/solidus_graphql_api/types/option_value.rb
@@ -10,6 +10,11 @@ module SolidusGraphqlApi
       field :position, String, null: false
       field :presentation, String, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :option_type, OptionType, null: false
+
+      def option_type
+        Queries::OptionValue::OptionTypeQuery.new(option_value: object).call
+      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -788,6 +788,7 @@ type OptionValue implements Node {
   createdAt: ISO8601DateTime
   id: ID!
   name: String!
+  optionType: OptionType!
   position: String!
   presentation: String!
   updatedAt: ISO8601DateTime

--- a/spec/lib/solidus_graphql_api/queries/option_value/option_type_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/option_value/option_type_query_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::OptionValue::OptionTypeQuery do
+  let(:option_type) { create(:option_type) }
+  let(:option_value) { create(:option_value, option_type: option_type) }
+
+  it { expect(described_class.new(option_value: option_value).call.sync).to eq(option_type) }
+end

--- a/spec/lib/solidus_graphql_api/types/option_value_spec.rb
+++ b/spec/lib/solidus_graphql_api/types/option_value_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Types::OptionValue do
+  let(:option_value) { create(:option_value) }
+  let(:query_object) { spy(:query_object) }
+
+  subject { described_class.send(:new, option_value, {}) }
+
+  describe '#option_type' do
+    before do
+      allow(SolidusGraphqlApi::Queries::OptionValue::OptionTypeQuery).
+        to receive(:new).with(option_value: option_value).
+        and_return(query_object)
+    end
+
+    after { subject.option_type }
+
+    it { expect(query_object).to receive(:call) }
+  end
+end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -788,6 +788,7 @@ type OptionValue implements Node {
   createdAt: ISO8601DateTime
   id: ID!
   name: String!
+  optionType: OptionType!
   position: String!
   presentation: String!
   updatedAt: ISO8601DateTime


### PR DESCRIPTION
This allows to retrieve option value values along their option type
name, description, etc. E.g.:

```graphql
query getProduct {
  productBySlug(slug: "solidus-t-shirt") {
    name
    description
    variants {
      nodes {
        id
        sku
        position
        prices {
          nodes {
            amount
            currency {
              htmlEntity
            }
          }
        }
        optionValues {
          nodes {
            id
            name
            presentation
            optionType {
              name
              position
              presentation
            }
          }
        }
      }
    }
  }
}
```

Fixes #171