### PR TITLE
Fix duplication of records on has_many_through associations

### DIFF
--- a/lib/solidus_graphql_api/batch_loader/has_many_through.rb
+++ b/lib/solidus_graphql_api/batch_loader/has_many_through.rb
@@ -24,6 +24,7 @@ module SolidusGraphqlApi
         base_relation
           .joins(through_reflection.name)
           .where("#{through_reflection.table_name}.#{through_reflection.foreign_key}" => object_ids)
+          .distinct
       end
 
       def group_records_by_parent(records)

--- a/spec/lib/solidus_graphql_api/batch_loader/has_many_through_spec.rb
+++ b/spec/lib/solidus_graphql_api/batch_loader/has_many_through_spec.rb
@@ -5,43 +5,55 @@ require 'spec_helper'
 RSpec.describe SolidusGraphqlApi::BatchLoader::HasManyThrough do
   subject(:loader) do
     described_class.new(
-      article,
-      Article.reflect_on_association(:comment_authors)
+      physician,
+      Physician.reflect_on_association(:patients)
     )
   end
 
-  with_model :Article, scope: :all do
+  with_model :Physician, scope: :all do
     model do
-      has_many :comments
-      has_many :comment_authors, through: :comments, source: :author
+      has_many :appointments
+      has_many :patients, through: :appointments
     end
   end
 
-  with_model :Comment, scope: :all do
+  with_model :Appointment, scope: :all do
     table do |t|
-      t.belongs_to :article
-      t.belongs_to :author
+      t.belongs_to :physician, index: { name: :appointment_on_physician }
+      t.belongs_to :patient
     end
 
     model do
-      belongs_to :article
-      belongs_to :author
+      belongs_to :physician
+      belongs_to :patient
     end
   end
 
-  with_model :Author, scope: :all do
+  with_model :Patient, scope: :all do
     model do
-      has_many :comments
+      has_many :appointments
     end
   end
 
-  let!(:article) { Article.create! }
+  let!(:physician) { Physician.create! }
 
   before do
-    article.comments.create!(author: Author.create!)
+    physician.appointments.create!(patient: Patient.create!)
   end
 
   it 'loads the association properly' do
-    expect(loader.load.sync).to eq(article.comment_authors)
+    expect(loader.load.sync).to eq(physician.patients)
+  end
+
+  it "doesn't duplicate result when another record loaded in the batch is also associated to the same target record" do
+    second_physician = Physician.create!
+    Appointment.create!(patient: physician.patients.first, physician: second_physician)
+
+    described_class.new(
+      second_physician,
+      Physician.reflect_on_association(:patients)
+    ).load
+
+    expect(loader.load.sync.length).to be(1)
   end
 end


### PR DESCRIPTION
When a batch included two records, both of them associated to the same
target record through a `has_many_through` association, the target
record was duplicated for both parent records.

We change the name of the models used in the test to reproduce an
example with a clearer business use-case behind.

Fixes #172