### PR TITLE
Add ShippingMethod type and associate to ShippingRate

### DIFF
--- a/docs/directive/deprecated/index.html
+++ b/docs/directive/deprecated/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/directive/include/index.html
+++ b/docs/directive/include/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/directive/index.html
+++ b/docs/directive/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/directive/skip/index.html
+++ b/docs/directive/skip/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/enum/__directivelocation/index.html
+++ b/docs/enum/__directivelocation/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/enum/__typekind/index.html
+++ b/docs/enum/__typekind/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/enum/index.html
+++ b/docs/enum/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/addaddressestocheckoutinput/index.html
+++ b/docs/input_object/addaddressestocheckoutinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/addpaymenttocheckoutinput/index.html
+++ b/docs/input_object/addpaymenttocheckoutinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/addressinput/index.html
+++ b/docs/input_object/addressinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/addtocartinput/index.html
+++ b/docs/input_object/addtocartinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/advancecheckoutinput/index.html
+++ b/docs/input_object/advancecheckoutinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/applycouponcodeinput/index.html
+++ b/docs/input_object/applycouponcodeinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/completecheckoutinput/index.html
+++ b/docs/input_object/completecheckoutinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/createorderinput/index.html
+++ b/docs/input_object/createorderinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/emptycartinput/index.html
+++ b/docs/input_object/emptycartinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/index.html
+++ b/docs/input_object/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/markdefaultshipaddressinput/index.html
+++ b/docs/input_object/markdefaultshipaddressinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/nextcheckoutstateinput/index.html
+++ b/docs/input_object/nextcheckoutstateinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/productsqueryinput/index.html
+++ b/docs/input_object/productsqueryinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/removefromaddressbookinput/index.html
+++ b/docs/input_object/removefromaddressbookinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/removefromcartinput/index.html
+++ b/docs/input_object/removefromcartinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/saveinaddressbookinput/index.html
+++ b/docs/input_object/saveinaddressbookinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/selectshippingrateinput/index.html
+++ b/docs/input_object/selectshippingrateinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/setorderemailinput/index.html
+++ b/docs/input_object/setorderemailinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/input_object/updatecartquantityinput/index.html
+++ b/docs/input_object/updatecartquantityinput/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/interface/adjustment/index.html
+++ b/docs/interface/adjustment/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/interface/index.html
+++ b/docs/interface/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/interface/node/index.html
+++ b/docs/interface/node/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>
@@ -1100,6 +1107,7 @@
    <li><code><a href="/solidus_graphql_api/docs/object/promotionadjustment">PromotionAdjustment</a></code></li>
    <li><code><a href="/solidus_graphql_api/docs/object/property">Property</a></code></li>
    <li><code><a href="/solidus_graphql_api/docs/object/shipment">Shipment</a></code></li>
+   <li><code><a href="/solidus_graphql_api/docs/object/shippingmethod">ShippingMethod</a></code></li>
    <li><code><a href="/solidus_graphql_api/docs/object/shippingrate">ShippingRate</a></code></li>
    <li><code><a href="/solidus_graphql_api/docs/object/state">State</a></code></li>
    <li><code><a href="/solidus_graphql_api/docs/object/store">Store</a></code></li>

--- a/docs/interface/paymentsource/index.html
+++ b/docs/interface/paymentsource/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/addaddressestocheckout/index.html
+++ b/docs/mutation/addaddressestocheckout/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/addpaymenttocheckout/index.html
+++ b/docs/mutation/addpaymenttocheckout/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/addtocart/index.html
+++ b/docs/mutation/addtocart/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/advancecheckout/index.html
+++ b/docs/mutation/advancecheckout/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/applycouponcode/index.html
+++ b/docs/mutation/applycouponcode/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/completecheckout/index.html
+++ b/docs/mutation/completecheckout/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/createorder/index.html
+++ b/docs/mutation/createorder/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/emptycart/index.html
+++ b/docs/mutation/emptycart/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/markdefaultshipaddress/index.html
+++ b/docs/mutation/markdefaultshipaddress/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/nextcheckoutstate/index.html
+++ b/docs/mutation/nextcheckoutstate/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/removefromaddressbook/index.html
+++ b/docs/mutation/removefromaddressbook/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/removefromcart/index.html
+++ b/docs/mutation/removefromcart/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/saveinaddressbook/index.html
+++ b/docs/mutation/saveinaddressbook/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/selectshippingrate/index.html
+++ b/docs/mutation/selectshippingrate/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/setorderemail/index.html
+++ b/docs/mutation/setorderemail/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/mutation/updatecartquantity/index.html
+++ b/docs/mutation/updatecartquantity/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__directive/index.html
+++ b/docs/object/__directive/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__enumvalue/index.html
+++ b/docs/object/__enumvalue/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__field/index.html
+++ b/docs/object/__field/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__inputvalue/index.html
+++ b/docs/object/__inputvalue/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__schema/index.html
+++ b/docs/object/__schema/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/__type/index.html
+++ b/docs/object/__type/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/addaddressestocheckoutpayload/index.html
+++ b/docs/object/addaddressestocheckoutpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/addpaymenttocheckoutpayload/index.html
+++ b/docs/object/addpaymenttocheckoutpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/address/index.html
+++ b/docs/object/address/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/addressconnection/index.html
+++ b/docs/object/addressconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/addressedge/index.html
+++ b/docs/object/addressedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/addtocartpayload/index.html
+++ b/docs/object/addtocartpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/adjustmentconnection/index.html
+++ b/docs/object/adjustmentconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/adjustmentedge/index.html
+++ b/docs/object/adjustmentedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/advancecheckoutpayload/index.html
+++ b/docs/object/advancecheckoutpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/applycouponcodepayload/index.html
+++ b/docs/object/applycouponcodepayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/completecheckoutpayload/index.html
+++ b/docs/object/completecheckoutpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/country/index.html
+++ b/docs/object/country/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/countryconnection/index.html
+++ b/docs/object/countryconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/countryedge/index.html
+++ b/docs/object/countryedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/createorderpayload/index.html
+++ b/docs/object/createorderpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/creditcard/index.html
+++ b/docs/object/creditcard/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/currency/index.html
+++ b/docs/object/currency/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/currencyconnection/index.html
+++ b/docs/object/currencyconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/currencyedge/index.html
+++ b/docs/object/currencyedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/emptycartpayload/index.html
+++ b/docs/object/emptycartpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/image/index.html
+++ b/docs/object/image/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/imageconnection/index.html
+++ b/docs/object/imageconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/imageedge/index.html
+++ b/docs/object/imageedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/index.html
+++ b/docs/object/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/lineitem/index.html
+++ b/docs/object/lineitem/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/lineitemconnection/index.html
+++ b/docs/object/lineitemconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/lineitemedge/index.html
+++ b/docs/object/lineitemedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/manifestitem/index.html
+++ b/docs/object/manifestitem/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/markdefaultshipaddresspayload/index.html
+++ b/docs/object/markdefaultshipaddresspayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/nextcheckoutstatepayload/index.html
+++ b/docs/object/nextcheckoutstatepayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optiontype/index.html
+++ b/docs/object/optiontype/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optiontypeconnection/index.html
+++ b/docs/object/optiontypeconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optiontypeedge/index.html
+++ b/docs/object/optiontypeedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optionvalue/index.html
+++ b/docs/object/optionvalue/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optionvalueconnection/index.html
+++ b/docs/object/optionvalueconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/optionvalueedge/index.html
+++ b/docs/object/optionvalueedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/order/index.html
+++ b/docs/object/order/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/orderconnection/index.html
+++ b/docs/object/orderconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/orderedge/index.html
+++ b/docs/object/orderedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/pageinfo/index.html
+++ b/docs/object/pageinfo/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/payment/index.html
+++ b/docs/object/payment/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/paymentmethod/index.html
+++ b/docs/object/paymentmethod/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/price/index.html
+++ b/docs/object/price/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/priceconnection/index.html
+++ b/docs/object/priceconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/priceedge/index.html
+++ b/docs/object/priceedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/product/index.html
+++ b/docs/object/product/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/productconnection/index.html
+++ b/docs/object/productconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/productedge/index.html
+++ b/docs/object/productedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/productproperty/index.html
+++ b/docs/object/productproperty/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/productpropertyconnection/index.html
+++ b/docs/object/productpropertyconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/productpropertyedge/index.html
+++ b/docs/object/productpropertyedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/promotionadjustment/index.html
+++ b/docs/object/promotionadjustment/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/property/index.html
+++ b/docs/object/property/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/removefromaddressbookpayload/index.html
+++ b/docs/object/removefromaddressbookpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/removefromcartpayload/index.html
+++ b/docs/object/removefromcartpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/saveinaddressbookpayload/index.html
+++ b/docs/object/saveinaddressbookpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/selectshippingratepayload/index.html
+++ b/docs/object/selectshippingratepayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/setorderemailpayload/index.html
+++ b/docs/object/setorderemailpayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/shipment/index.html
+++ b/docs/object/shipment/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/shipmentconnection/index.html
+++ b/docs/object/shipmentconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/shipmentedge/index.html
+++ b/docs/object/shipmentedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/shippingmethod/index.html
+++ b/docs/object/shippingmethod/index.html
@@ -1,0 +1,1167 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="description" content="ShippingMethod GraphQL documentation">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>ShippingMethod</title>
+    <link rel="stylesheet" href="/solidus_graphql_api/docs/assets/style.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.2/anchor.min.js"></script>
+    <script>
+
+    // Add anchors on DOMContentLoaded
+    document.addEventListener("DOMContentLoaded", function(event) {
+      anchors.options = {
+        placement: 'left',
+        visible: 'hover',
+        icon: '¶'
+      };
+      anchors.add('h2, h3, h4, h5, h6, .anchored');
+    });
+
+    </script>
+  </head>
+  <body>
+
+    <div id="wrap">
+      <div id="header">
+      </div>
+      <div id="sidebar">
+        <ul class="categories">
+  <li>
+    <ul class="menu-root">
+      <li>
+        <a href="/solidus_graphql_api/docs">GraphQL Reference</a>
+    </ul>
+  </li>
+
+  <li>
+    <p>Queries</p>
+    <ul class="menu-root">
+      <li>
+        <a href="/solidus_graphql_api/docs/operation/query/" class="sidebar-link">
+          Query
+        </a>
+      </li>
+      <li>
+        <a href="/solidus_graphql_api/docs/operation/mutation/" class="sidebar-link">
+          Mutation
+        </a>
+      </li>
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/object">Objects</a></p>
+    <ul class="menu-root">
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/addaddressestocheckoutpayload/" class="sidebar-link">
+          AddAddressesToCheckoutPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/addpaymenttocheckoutpayload/" class="sidebar-link">
+          AddPaymentToCheckoutPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/addtocartpayload/" class="sidebar-link">
+          AddToCartPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/address/" class="sidebar-link">
+          Address
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/addressconnection/" class="sidebar-link">
+          AddressConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/addressedge/" class="sidebar-link">
+          AddressEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/adjustmentconnection/" class="sidebar-link">
+          AdjustmentConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/adjustmentedge/" class="sidebar-link">
+          AdjustmentEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/advancecheckoutpayload/" class="sidebar-link">
+          AdvanceCheckoutPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/applycouponcodepayload/" class="sidebar-link">
+          ApplyCouponCodePayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/completecheckoutpayload/" class="sidebar-link">
+          CompleteCheckoutPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/country/" class="sidebar-link">
+          Country
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/countryconnection/" class="sidebar-link">
+          CountryConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/countryedge/" class="sidebar-link">
+          CountryEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/createorderpayload/" class="sidebar-link">
+          CreateOrderPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/creditcard/" class="sidebar-link">
+          CreditCard
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/currency/" class="sidebar-link">
+          Currency
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/currencyconnection/" class="sidebar-link">
+          CurrencyConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/currencyedge/" class="sidebar-link">
+          CurrencyEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/emptycartpayload/" class="sidebar-link">
+          EmptyCartPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/image/" class="sidebar-link">
+          Image
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/imageconnection/" class="sidebar-link">
+          ImageConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/imageedge/" class="sidebar-link">
+          ImageEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/lineitem/" class="sidebar-link">
+          LineItem
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/lineitemconnection/" class="sidebar-link">
+          LineItemConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/lineitemedge/" class="sidebar-link">
+          LineItemEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/manifestitem/" class="sidebar-link">
+          ManifestItem
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/markdefaultshipaddresspayload/" class="sidebar-link">
+          MarkDefaultShipAddressPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/nextcheckoutstatepayload/" class="sidebar-link">
+          NextCheckoutStatePayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optiontype/" class="sidebar-link">
+          OptionType
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optiontypeconnection/" class="sidebar-link">
+          OptionTypeConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optiontypeedge/" class="sidebar-link">
+          OptionTypeEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optionvalue/" class="sidebar-link">
+          OptionValue
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optionvalueconnection/" class="sidebar-link">
+          OptionValueConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/optionvalueedge/" class="sidebar-link">
+          OptionValueEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/order/" class="sidebar-link">
+          Order
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/orderconnection/" class="sidebar-link">
+          OrderConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/orderedge/" class="sidebar-link">
+          OrderEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/pageinfo/" class="sidebar-link">
+          PageInfo
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/payment/" class="sidebar-link">
+          Payment
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/paymentmethod/" class="sidebar-link">
+          PaymentMethod
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/price/" class="sidebar-link">
+          Price
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/priceconnection/" class="sidebar-link">
+          PriceConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/priceedge/" class="sidebar-link">
+          PriceEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/product/" class="sidebar-link">
+          Product
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/productconnection/" class="sidebar-link">
+          ProductConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/productedge/" class="sidebar-link">
+          ProductEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/productproperty/" class="sidebar-link">
+          ProductProperty
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/productpropertyconnection/" class="sidebar-link">
+          ProductPropertyConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/productpropertyedge/" class="sidebar-link">
+          ProductPropertyEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/promotionadjustment/" class="sidebar-link">
+          PromotionAdjustment
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/property/" class="sidebar-link">
+          Property
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/removefromaddressbookpayload/" class="sidebar-link">
+          RemoveFromAddressBookPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/removefromcartpayload/" class="sidebar-link">
+          RemoveFromCartPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/saveinaddressbookpayload/" class="sidebar-link">
+          SaveInAddressBookPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/selectshippingratepayload/" class="sidebar-link">
+          SelectShippingRatePayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/setorderemailpayload/" class="sidebar-link">
+          SetOrderEmailPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shipment/" class="sidebar-link">
+          Shipment
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shipmentconnection/" class="sidebar-link">
+          ShipmentConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shipmentedge/" class="sidebar-link">
+          ShipmentEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
+          ShippingRate
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shippingrateconnection/" class="sidebar-link">
+          ShippingRateConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/shippingrateedge/" class="sidebar-link">
+          ShippingRateEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/state/" class="sidebar-link">
+          State
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/stateconnection/" class="sidebar-link">
+          StateConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/stateedge/" class="sidebar-link">
+          StateEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/store/" class="sidebar-link">
+          Store
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxadjustment/" class="sidebar-link">
+          TaxAdjustment
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxon/" class="sidebar-link">
+          Taxon
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxonconnection/" class="sidebar-link">
+          TaxonConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxonedge/" class="sidebar-link">
+          TaxonEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxonomy/" class="sidebar-link">
+          Taxonomy
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxonomyconnection/" class="sidebar-link">
+          TaxonomyConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/taxonomyedge/" class="sidebar-link">
+          TaxonomyEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/updatecartquantitypayload/" class="sidebar-link">
+          UpdateCartQuantityPayload
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/user/" class="sidebar-link">
+          User
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/usererror/" class="sidebar-link">
+          UserError
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/variant/" class="sidebar-link">
+          Variant
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/variantconnection/" class="sidebar-link">
+          VariantConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/variantedge/" class="sidebar-link">
+          VariantEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/walletpaymentsource/" class="sidebar-link">
+          WalletPaymentSource
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/walletpaymentsourceconnection/" class="sidebar-link">
+          WalletPaymentSourceConnection
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/walletpaymentsourceedge/" class="sidebar-link">
+          WalletPaymentSourceEdge
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__directive/" class="sidebar-link">
+          __Directive
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__enumvalue/" class="sidebar-link">
+          __EnumValue
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__field/" class="sidebar-link">
+          __Field
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__inputvalue/" class="sidebar-link">
+          __InputValue
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__schema/" class="sidebar-link">
+          __Schema
+        </a>
+      </li>
+      
+        
+      <li>
+        <a href="/solidus_graphql_api/docs/object/__type/" class="sidebar-link">
+          __Type
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/operation/mutation">Mutations</a></p>
+    <ul class="menu-root">
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/addaddressestocheckout/" class="sidebar-link">
+          addAddressesToCheckout
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/addpaymenttocheckout/" class="sidebar-link">
+          addPaymentToCheckout
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/addtocart/" class="sidebar-link">
+          addToCart
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/advancecheckout/" class="sidebar-link">
+          advanceCheckout
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/applycouponcode/" class="sidebar-link">
+          applyCouponCode
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/completecheckout/" class="sidebar-link">
+          completeCheckout
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/createorder/" class="sidebar-link">
+          createOrder
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/emptycart/" class="sidebar-link">
+          emptyCart
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/markdefaultshipaddress/" class="sidebar-link">
+          markDefaultShipAddress
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/nextcheckoutstate/" class="sidebar-link">
+          nextCheckoutState
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/removefromaddressbook/" class="sidebar-link">
+          removeFromAddressBook
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/removefromcart/" class="sidebar-link">
+          removeFromCart
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/saveinaddressbook/" class="sidebar-link">
+          saveInAddressBook
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/selectshippingrate/" class="sidebar-link">
+          selectShippingRate
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/setorderemail/" class="sidebar-link">
+          setOrderEmail
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/mutation/updatecartquantity/" class="sidebar-link">
+          updateCartQuantity
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/interface">Interfaces</a></p>
+    <ul class="menu-root">
+      
+        
+        <li>
+          <a href="/solidus_graphql_api/docs/interface/adjustment/" class="sidebar-link">
+            Adjustment
+          </a>
+        </li>
+      
+        
+        <li>
+          <a href="/solidus_graphql_api/docs/interface/node/" class="sidebar-link">
+            Node
+          </a>
+        </li>
+      
+        
+        <li>
+          <a href="/solidus_graphql_api/docs/interface/paymentsource/" class="sidebar-link">
+            PaymentSource
+          </a>
+        </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/enum">Enums</a></p>
+    <ul class="menu-root">
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/enum/__directivelocation/" class="sidebar-link">
+          __DirectiveLocation
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/enum/__typekind/" class="sidebar-link">
+          __TypeKind
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/union">Unions</a></p>
+    <ul class="menu-root">
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/input_object">Input Objects</a></p>
+    <ul class="menu-root">
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/addaddressestocheckoutinput/" class="sidebar-link">
+          AddAddressesToCheckoutInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/addpaymenttocheckoutinput/" class="sidebar-link">
+          AddPaymentToCheckoutInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/addtocartinput/" class="sidebar-link">
+          AddToCartInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/addressinput/" class="sidebar-link">
+          AddressInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/advancecheckoutinput/" class="sidebar-link">
+          AdvanceCheckoutInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/applycouponcodeinput/" class="sidebar-link">
+          ApplyCouponCodeInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/completecheckoutinput/" class="sidebar-link">
+          CompleteCheckoutInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/createorderinput/" class="sidebar-link">
+          CreateOrderInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/emptycartinput/" class="sidebar-link">
+          EmptyCartInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/markdefaultshipaddressinput/" class="sidebar-link">
+          MarkDefaultShipAddressInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/nextcheckoutstateinput/" class="sidebar-link">
+          NextCheckoutStateInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/productsqueryinput/" class="sidebar-link">
+          ProductsQueryInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/removefromaddressbookinput/" class="sidebar-link">
+          RemoveFromAddressBookInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/removefromcartinput/" class="sidebar-link">
+          RemoveFromCartInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/saveinaddressbookinput/" class="sidebar-link">
+          SaveInAddressBookInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/selectshippingrateinput/" class="sidebar-link">
+          SelectShippingRateInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/setorderemailinput/" class="sidebar-link">
+          SetOrderEmailInput
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/input_object/updatecartquantityinput/" class="sidebar-link">
+          UpdateCartQuantityInput
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/scalar">Scalars</a></p>
+    <ul class="menu-root">
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/boolean/" class="sidebar-link">
+          Boolean
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/float/" class="sidebar-link">
+          Float
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/id/" class="sidebar-link">
+          ID
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/iso8601datetime/" class="sidebar-link">
+          ISO8601DateTime
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/int/" class="sidebar-link">
+          Int
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/json/" class="sidebar-link">
+          Json
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/scalar/string/" class="sidebar-link">
+          String
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+
+  <li>
+    <p><a href="/solidus_graphql_api/docs/directive">Directives</a></p>
+    <ul class="menu-root">
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/directive/deprecated/" class="sidebar-link">
+          deprecated
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/directive/include/" class="sidebar-link">
+          include
+        </a>
+      </li>
+      
+      
+      <li>
+        <a href="/solidus_graphql_api/docs/directive/skip/" class="sidebar-link">
+          skip
+        </a>
+      </li>
+      
+    </ul>
+  </li>
+</ul>
+
+      </div>
+      <div id="content">
+
+        <h1>
+<a id="shippingmethod" class="anchor" href="#shippingmethod" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>ShippingMethod</h1>
+<p>Shipping Method.</p>
+<h2>
+<a id="implements" class="anchor" href="#implements" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Implements</h2>
+<ul>
+   <li><code><a href="/solidus_graphql_api/docs/interface/node">Node</a></code></li>
+</ul>
+<h2>
+<a id="fields" class="anchor" href="#fields" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Fields</h2>
+<div class="field-entry ">
+  <span id="id" class="field-name anchored">id (<code><a href="/solidus_graphql_api/docs/scalar/id">ID!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="adminname" class="field-name anchored">adminName (<code><a href="/solidus_graphql_api/docs/scalar/string">String</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="availabletoall" class="field-name anchored">availableToAll (<code><a href="/solidus_graphql_api/docs/scalar/boolean">Boolean!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="availabletousers" class="field-name anchored">availableToUsers (<code><a href="/solidus_graphql_api/docs/scalar/boolean">Boolean!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="carrier" class="field-name anchored">carrier (<code><a href="/solidus_graphql_api/docs/scalar/string">String</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="code" class="field-name anchored">code (<code><a href="/solidus_graphql_api/docs/scalar/string">String</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="createdat" class="field-name anchored">createdAt (<code><a href="/solidus_graphql_api/docs/scalar/iso8601datetime">ISO8601DateTime</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="name" class="field-name anchored">name (<code><a href="/solidus_graphql_api/docs/scalar/string">String!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="servicelevel" class="field-name anchored">serviceLevel (<code><a href="/solidus_graphql_api/docs/scalar/string">String</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="trackingurl" class="field-name anchored">trackingUrl (<code><a href="/solidus_graphql_api/docs/scalar/string">String</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="updatedat" class="field-name anchored">updatedAt (<code><a href="/solidus_graphql_api/docs/scalar/iso8601datetime">ISO8601DateTime</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+
+      </div>
+
+      <!-- mobile only -->
+      <div id="mobile-header">
+        <a class="menu-button" onclick="document.body.classList.toggle('sidebar-open')"></a>
+        <a class="logo" href="/solidus_graphql_api/docs">
+
+        </a>
+      </div>
+      <div id="mobile-shade"></div>
+
+    </div>
+
+  </body>
+</html>

--- a/docs/object/shippingrate/index.html
+++ b/docs/object/shippingrate/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>
@@ -1109,6 +1116,11 @@
 </div>
 <div class="field-entry ">
   <span id="selected" class="field-name anchored">selected (<code><a href="/solidus_graphql_api/docs/scalar/boolean">Boolean!</a></code>)</span>
+  <div class="description-wrapper">
+  </div>
+</div>
+<div class="field-entry ">
+  <span id="shippingmethod" class="field-name anchored">shippingMethod (<code><a href="/solidus_graphql_api/docs/object/shippingmethod">ShippingMethod!</a></code>)</span>
   <div class="description-wrapper">
   </div>
 </div>

--- a/docs/object/shippingrateconnection/index.html
+++ b/docs/object/shippingrateconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/shippingrateedge/index.html
+++ b/docs/object/shippingrateedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/state/index.html
+++ b/docs/object/state/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/stateconnection/index.html
+++ b/docs/object/stateconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/stateedge/index.html
+++ b/docs/object/stateedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/store/index.html
+++ b/docs/object/store/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxadjustment/index.html
+++ b/docs/object/taxadjustment/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxon/index.html
+++ b/docs/object/taxon/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxonconnection/index.html
+++ b/docs/object/taxonconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxonedge/index.html
+++ b/docs/object/taxonedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxonomy/index.html
+++ b/docs/object/taxonomy/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxonomyconnection/index.html
+++ b/docs/object/taxonomyconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/taxonomyedge/index.html
+++ b/docs/object/taxonomyedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/updatecartquantitypayload/index.html
+++ b/docs/object/updatecartquantitypayload/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/user/index.html
+++ b/docs/object/user/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/usererror/index.html
+++ b/docs/object/usererror/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/variant/index.html
+++ b/docs/object/variant/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/variantconnection/index.html
+++ b/docs/object/variantconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/variantedge/index.html
+++ b/docs/object/variantedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/walletpaymentsource/index.html
+++ b/docs/object/walletpaymentsource/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/walletpaymentsourceconnection/index.html
+++ b/docs/object/walletpaymentsourceconnection/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/object/walletpaymentsourceedge/index.html
+++ b/docs/object/walletpaymentsourceedge/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/operation/mutation/index.html
+++ b/docs/operation/mutation/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/operation/query/index.html
+++ b/docs/operation/query/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/boolean/index.html
+++ b/docs/scalar/boolean/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/float/index.html
+++ b/docs/scalar/float/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/id/index.html
+++ b/docs/scalar/id/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/index.html
+++ b/docs/scalar/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/int/index.html
+++ b/docs/scalar/int/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/iso8601datetime/index.html
+++ b/docs/scalar/iso8601datetime/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/json/index.html
+++ b/docs/scalar/json/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/scalar/string/index.html
+++ b/docs/scalar/string/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/docs/union/index.html
+++ b/docs/union/index.html
@@ -477,6 +477,13 @@
       
         
       <li>
+        <a href="/solidus_graphql_api/docs/object/shippingmethod/" class="sidebar-link">
+          ShippingMethod
+        </a>
+      </li>
+      
+        
+      <li>
         <a href="/solidus_graphql_api/docs/object/shippingrate/" class="sidebar-link">
           ShippingRate
         </a>

--- a/lib/solidus_graphql_api/queries/shipping_rate/shipping_method_query.rb
+++ b/lib/solidus_graphql_api/queries/shipping_rate/shipping_method_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module ShippingRate
+      class ShippingMethodQuery
+        attr_reader :shipping_rate
+
+        def initialize(shipping_rate:)
+          @shipping_rate = shipping_rate
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(shipping_rate, :shipping_method)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/shipping_method.rb
+++ b/lib/solidus_graphql_api/types/shipping_method.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class ShippingMethod < Base::RelayNode
+      description 'Shipping Method.'
+
+      field :name, String, null: false
+      field :tracking_url, String, null: true
+      field :admin_name, String, null: true
+      field :code, String, null: true
+      field :carrier, String, null: true
+      field :service_level, String, null: true
+      field :available_to_users, Boolean, null: false
+      field :available_to_all, Boolean, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/shipping_rate.rb
+++ b/lib/solidus_graphql_api/types/shipping_rate.rb
@@ -10,6 +10,11 @@ module SolidusGraphqlApi
       field :currency, String, null: false
       field :selected, Boolean, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :shipping_method, ShippingMethod, null: false
+
+      def shipping_method
+        Queries::ShippingRate::ShippingMethodQuery.new(shipping_rate: object).call
+      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1604,6 +1604,23 @@ type ShipmentEdge {
 }
 
 """
+Shipping Method.
+"""
+type ShippingMethod implements Node {
+  adminName: String
+  availableToAll: Boolean!
+  availableToUsers: Boolean!
+  carrier: String
+  code: String
+  createdAt: ISO8601DateTime
+  id: ID!
+  name: String!
+  serviceLevel: String
+  trackingUrl: String
+  updatedAt: ISO8601DateTime
+}
+
+"""
 Shipping Rate.
 """
 type ShippingRate implements Node {
@@ -1612,6 +1629,7 @@ type ShippingRate implements Node {
   currency: String!
   id: ID!
   selected: Boolean!
+  shippingMethod: ShippingMethod!
   updatedAt: ISO8601DateTime
 }
 

--- a/spec/lib/solidus_graphql_api/queries/shipping_rate/shipping_method_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/shipping_rate/shipping_method_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::ShippingRate::ShippingMethodQuery do
+  let(:shipping_method) { create(:shipping_method) }
+
+  let(:shipping_rate) { create(:shipping_rate, shipping_method: shipping_method) }
+
+  it { expect(described_class.new(shipping_rate: shipping_rate).call.sync).to eq(shipping_method) }
+end

--- a/spec/lib/solidus_graphql_api/types/shipping_rate_spec.rb
+++ b/spec/lib/solidus_graphql_api/types/shipping_rate_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Types::ShippingRate do
+  let(:shipping_rate) { create(:shipping_rate) }
+  let(:query_object) { spy(:query_object) }
+
+  subject { described_class.send(:new, shipping_rate, {}) }
+
+  describe '#shipping_method' do
+    before do
+      allow(SolidusGraphqlApi::Queries::ShippingRate::ShippingMethodQuery).
+        to receive(:new).with(shipping_rate: shipping_rate).
+        and_return(query_object)
+    end
+
+    after { subject.shipping_method }
+
+    it { expect(query_object).to receive(:call) }
+  end
+end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -1604,6 +1604,23 @@ type ShipmentEdge {
 }
 
 """
+Shipping Method.
+"""
+type ShippingMethod implements Node {
+  adminName: String
+  availableToAll: Boolean!
+  availableToUsers: Boolean!
+  carrier: String
+  code: String
+  createdAt: ISO8601DateTime
+  id: ID!
+  name: String!
+  serviceLevel: String
+  trackingUrl: String
+  updatedAt: ISO8601DateTime
+}
+
+"""
 Shipping Rate.
 """
 type ShippingRate implements Node {
@@ -1612,6 +1629,7 @@ type ShippingRate implements Node {
   currency: String!
   id: ID!
   selected: Boolean!
+  shippingMethod: ShippingMethod!
   updatedAt: ISO8601DateTime
 }
 


### PR DESCRIPTION
It allows querying the shipping rates information for orders along
with the shipping method information, which is something that usually
needs to be displayed to the end-user.

Example:

```graphql
query shippingInformation {
  currentOrder {
    shipments {
      nodes {
        shippingRates {
          nodes {
            cost
            currency
            shippingMethod {
              name
              trackingUrl
              carrier
            }
          }
        }
      }
    }
  }
}
```

Response:

```json
{
  "data": {
    "currentOrder": {
      "shipments": {
        "nodes": [
          {
            "shippingRates": {
              "nodes": [
                {
                  "cost": "5.0",
                  "currency": "USD",
                  "shippingMethod": {
                    "name": "UPS Ground (USD)",
                    "trackingUrl": null,
                    "carrier": null
                  }
                },
                {
                  "cost": "10.0",
                  "currency": "USD",
                  "shippingMethod": {
                    "name": "UPS Two Day (USD)",
                    "trackingUrl": null,
                    "carrier": null
                  }
                },
                {
                  "cost": "15.0",
                  "currency": "USD",
                  "shippingMethod": {
                    "name": "UPS One Day (USD)",
                    "trackingUrl": null,
                    "carrier": null
                  }
                }
              ]
            }
          }
        ]
      }
    }
```

Fixes #179