### PR TITLE
Fix rendering blob URLs on disk storage

### DIFF
--- a/app/controllers/spree/graphql_controller.rb
+++ b/app/controllers/spree/graphql_controller.rb
@@ -2,6 +2,8 @@
 
 module Spree
   class GraphqlController < ApplicationController
+    include ActiveStorage::SetCurrent
+
     skip_before_action :verify_authenticity_token
 
     def execute

--- a/spec/requests/spree/graphql_controller_spec.rb
+++ b/spec/requests/spree/graphql_controller_spec.rb
@@ -7,11 +7,24 @@ RSpec.describe Spree::GraphqlController do
 
   before { allow_any_instance_of(SolidusGraphqlApi::Context).to receive(:to_h).and_return(context) }
 
-  after { post '/graphql', headers: headers }
-
   it 'passes the right context to the schema' do
     expect(SolidusGraphqlApi::Schema).to receive(:execute).with(
       nil, hash_including(context: context)
     )
+
+    post '/graphql', headers: headers
+  end
+
+  it 'can return blob URLs on disk storage' do
+    product = create(:product)
+    product.images.create(attributes_for(:image))
+
+    post '/graphql',
+         params: {
+           query: "{ productBySlug(slug: \"#{product.slug}\") { masterVariant { images { nodes { smallUrl } } } } }"
+         },
+         headers: headers
+
+    expect(JSON.parse(response.body).dig(*%w[data productBySlug masterVariant images nodes])[0]['smallUrl']).to match('http://')
   end
 end


### PR DESCRIPTION
When `ActiveStorage` is configured on the disk service, it needs for the
controller to include `ActiveStorage::SetCurrent` to generate URLs.

See https://api.rubyonrails.org/v6.1/classes/ActiveStorage/SetCurrent.html