### PR TITLE
Fix error on JSON type after update to graphql 1.12

### DIFF
--- a/lib/solidus_graphql_api/types/json.rb
+++ b/lib/solidus_graphql_api/types/json.rb
@@ -4,6 +4,7 @@ module SolidusGraphqlApi
   module Types
     class Json < GraphQL::Types::JSON
       def self.coerce_input(value, ctx)
+        value = value.is_a?(ActionController::Parameters) ? value.permit!.to_h : value.to_h
         value.each do |key, field|
           case field
           when String

--- a/spec/integration/types/json_spec.rb
+++ b/spec/integration/types/json_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'JSON type' do
+  it 'coerces JSON custom type', type: :feature do
+    create(:product, name: 'Shirt')
+
+    post '/graphql',
+      params: {
+        query: "{ products(query: { search: { name_cont: \"Shirt\" } }) { nodes { name } } }"
+      },
+      headers: headers
+
+    expect(JSON.parse(response.body).dig(*%w[data products nodes])[0]['name']).to eq('Shirt')
+  end
+end


### PR DESCRIPTION
After the update, `GraphQL::Language::Nodes::InputObject` no longer is
enumerable without explicitly coercing it to a hash.

When the input is an `ActionController::Parameter` instance, we have to
`permit!` it before being able to coerce to hash.

@rainerdema @ChristianRimondi, it's not clear to me in which case that method can take `ActionController::Parameter` as input, I'd appreciate your insight here in case you can recall it :slightly_smiling_face: 